### PR TITLE
Add JCDS direct chunking method of upload which is what jamf cloud normally does.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+certifi==2020.6.20
+chardet==3.0.4
+idna==2.10
+requests==2.24.0
+requests-toolbelt==0.9.1
+six==1.15.0
+urllib3==1.25.9


### PR DESCRIPTION
This is the method by which the UI uploads packages to JCDS now, they don't use dbfileupload except in the old jamf admin gui client. Its a bit of a rough cut but you get the idea.