### PR TITLE
Fixed issue with credentials

### DIFF
--- a/jamf_pkg_upload.py
+++ b/jamf_pkg_upload.py
@@ -607,7 +607,7 @@ def main():
     }
 
     # grab values from a prefs file if supplied
-    jamf_url, jamf_user, jamf_password, enc_creds = api_connect.get_creds_from_args(
+    jamf_url, jamf_user, jamf_password, slack_webhook, enc_creds = api_connect.get_creds_from_args(
         args
     )
 


### PR DESCRIPTION
Slack webhook is returned from api_connect.get_creds_from_args but no variable in main was being assigned to it and script was failing with unpacking error.

jwrn3@mac jamf-upload % ./jamf_pkg_upload.py --verbose --prefs ~/Library/Preferences/com.github.autopkg.plist --category Printers /Volumes/Kyocera\ OS\ X\ 10.9+\ Web\ build\ 2020.07.01/Kyocera\ OS\ X\ 10.9+\ Web\ build\ 2020.07.01.pkg

** Jamf package upload script
** Uploads packages to Jamf Cloud or SMB Distribution Points.
Traceback (most recent call last):
  File "/Users/jwrn3/Support/repos/jamf-pro/jamf-upload/./jamf_pkg_upload.py", line 838, in <module>
    main()
  File "/Users/jwrn3/Support/repos/jamf-pro/jamf-upload/./jamf_pkg_upload.py", line 610, in main
    jamf_url, jamf_user, jamf_password, enc_creds = api_connect.get_creds_from_args(
ValueError: too many values to unpack (expected 4)