### PR TITLE
Fixed os_requirements not being included correctly in pkg XML

### DIFF
--- a/JamfUploaderProcessors/JamfPackageUploader.py
+++ b/JamfUploaderProcessors/JamfPackageUploader.py
@@ -86,7 +86,7 @@ class JamfPackageUploader(JamfUploaderBase):
             ),
             "default": "",
         },
-        "os_requirement": {
+        "os_requirements": {
             "required": False,
             "description": "Package OS requirement",
             "default": "",
@@ -359,7 +359,7 @@ class JamfPackageUploader(JamfUploaderBase):
             + f"<priority>{pkg_metadata['priority']}</priority>"
             + f"<reboot_required>{pkg_metadata['reboot_required']}</reboot_required>"
             + f"<required_processor>{pkg_metadata['required_processor']}</required_processor>"
-            + f"<os_requirement>{pkg_metadata['os_requirement']}</os_requirement>"
+            + f"<os_requirements>{pkg_metadata['os_requirements']}</os_requirements>"
             + f"<hash_type>{hash_type}</hash_type>"
             + f"<hash_value>{hash_value}</hash_value>"
             + f"<send_notification>{pkg_metadata['send_notification']}</send_notification>"
@@ -454,7 +454,7 @@ class JamfPackageUploader(JamfUploaderBase):
             "notes": self.env.get("pkg_notes"),
             "reboot_required": self.reboot_required,
             "priority": self.env.get("pkg_priority"),
-            "os_requirement": self.env.get("os_requirement"),
+            "os_requirements": self.env.get("os_requirements"),
             "required_processor": self.env.get("required_processor"),
             "send_notification": self.send_notification,
         }

--- a/JamfUploaderProcessors/READMEs/JamfPackageUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfPackageUploader.md
@@ -36,7 +36,7 @@ The pkg recipe must output pkg_path or this will fail.
   - **required:** False
   - **description:** Whether a package requires a reboot after installation.
   - **default:**
-- **os_requirement:**
+- **os_requirements:**
   - **required:** False
   - **description:** Package OS requirement
 - **required_processor:**

--- a/jamf-upload.sh
+++ b/jamf-upload.sh
@@ -501,8 +501,8 @@ while test $# -gt 0 ; do
             ## allows --os_requirement, --os-requirement, --osrequirements
             shift
             if [[ $processor == "JamfPackageUploader" || $processor == "JamfPackageUploaderGUI" ]]; then
-                if defaults write "$temp_processor_plist" os_requirement "$1"; then
-                    echo "   [jamf-upload] Wrote os_requirement='$1' into $temp_processor_plist"
+                if defaults write "$temp_processor_plist" os_requirements "$1"; then
+                    echo "   [jamf-upload] Wrote os_requirements='$1' into $temp_processor_plist"
                 fi
             elif [[ $processor == "JamfScriptUploader" ]]; then
                 if defaults write "$temp_processor_plist" osrequirements "$1"; then

--- a/jamf_pkg_upload.py
+++ b/jamf_pkg_upload.py
@@ -211,7 +211,7 @@ def update_pkg_metadata(
         + f"<priority>{pkg_metadata['priority']}</priority>"
         + f"<reboot_required>{pkg_metadata['reboot_required']}</reboot_required>"
         + f"<required_processor>{pkg_metadata['required_processor']}</required_processor>"
-        + f"<os_requirement>{pkg_metadata['os_requirement']}</os_requirement>"
+        + f"<os_requirements>{pkg_metadata['os_requirements']}</os_requirements>"
         + f"<hash_type>{hash_type}</hash_type>"
         + f"<hash_value>{hash_value}</hash_value>"
         + f"<send_notification>{pkg_metadata['send_notification']}</send_notification>"
@@ -378,7 +378,7 @@ def update_pkg_by_form(
             "notes": pkg_metadata["notes"],
             "priority": pkg_metadata["priority"],
             "uninstall_disabled": "true",
-            "osRequirements": pkg_metadata["os_requirement"],
+            "osRequirements": pkg_metadata["os_requirements"],
             "requiredProcessor": pkg_metadata["required_processor"],
             "switchWithPackageID": "-1",
             "action": "Save",
@@ -504,7 +504,7 @@ def get_args():
         help="a priority to assign to the package (default=10)",
     )
     parser.add_argument(
-        "--os_requirement",
+        "--os_requirements",
         default="",
         help="an OS requirements string to assign to the package",
     )
@@ -561,7 +561,7 @@ def main():
         "notes": args.notes,
         "reboot_required": args.reboot_required,
         "priority": args.priority,
-        "os_requirement": args.os_requirement,
+        "os_requirements": args.os_requirements,
         "required_processor": args.required_processor,
         "send_notification": args.send_notification,
     }


### PR DESCRIPTION
This PR fixes `JamfPackageUploader` not correctly setting a package's OS requirements due to an incorrectly named XML key.

This changes the uploaded XML key from `os_requirement` to `os_requirements`, as detailed in the [Jamf API documentation](https://developer.jamf.com/jamf-pro/reference/createpackagebyid). The processor itself has also been modified to only accept `os_requirements` as an input key, and the README for the processor has also been updated to reflect this.

Any scripts that reference the processor have also been modified to use the correct input key.

As a sidenote: in `jamf-upload.sh`, at line 503, both the condition for `JamfPackageUploader` and `JamfScriptUploader` now do the same thing, rendering the double condition redundant. I did't remove it, but it could be removed (or merged) in the future.