### PR TITLE
Add 'JamfPatchUploader'

### DIFF
--- a/JamfUploaderProcessors/JamfPatchUploader.py
+++ b/JamfUploaderProcessors/JamfPatchUploader.py
@@ -7,7 +7,6 @@ JamfPatchUploader processor for uploading a patch policy to Jamf Pro using AutoP
 
 import os.path
 import sys
-import xml.etree.cElementTree as ET
 
 from time import sleep
 from autopkglib import ProcessorError  # pylint: disable=import-error

--- a/JamfUploaderProcessors/JamfPatchUploader.py
+++ b/JamfUploaderProcessors/JamfPatchUploader.py
@@ -56,9 +56,9 @@ class JamfPatchUploader(JamfUploaderBase):
         },
         "patch_softwaretitle": {
             "required": True,
-            "description": "Name of the patch softwaretitel (e.g. 'Mozilla Firefox') used in Jamf. " +
+            "description": "Name of the patch softwaretitle (e.g. 'Mozilla Firefox') used in Jamf. " +
             "You need to create the patch softwaretitle by hand, since there is currently no way " +
-            "to craete these via the API.",
+            "to create these via the API.",
             "default": "",
         },
         "patch_name": {
@@ -154,7 +154,6 @@ class JamfPatchUploader(JamfUploaderBase):
             sleep(30)
         return r
 
-
     def main(self):
         """Do the main thing here"""
         self.jamf_url = self.env.get("JSS_URL")
@@ -183,7 +182,6 @@ class JamfPatchUploader(JamfUploaderBase):
                     f"ERROR: Patch Template file {self.patch_template} not found"
                 )
 
-
         self.output(f"Checking for existing '{self.patch_softwaretitle}' on {self.jamf_url}")
 
         # obtain the relevant credentials
@@ -193,7 +191,7 @@ class JamfPatchUploader(JamfUploaderBase):
 
         # -- Patch Icon
         # Sadly there is currently no (reasonable) way to upload an icon for a patch policy.
-        # We can only upload icons for non-patch polcies, and use them in patch policies afterwards.
+        # We can only upload icons for non-patch policies, and use them in patch policies afterwards.
         # Since most AutoPKG workflows include a policy (incl. an icon), we simply provide a way
         # to extract the icon from a specified policy (if desired).
 
@@ -207,7 +205,7 @@ class JamfPatchUploader(JamfUploaderBase):
             self.patch_icon_policy_id = 0
             self.output(
                 "No 'patch_icon_policy_name' was provided. Skipping icon extraction...",
-                verbose_level = 1
+                verbose_level=1
             )
 
         if self.patch_icon_policy_id and self.patch_icon_policy_name:
@@ -238,7 +236,6 @@ class JamfPatchUploader(JamfUploaderBase):
             self.output(
                 "WARNING: No icon found in given policy '{}'!".format(self.patch_icon_policy_name)
             )
-
 
         # -- Patch Softwaretitle
         obj_type = "patch_software_title"
@@ -287,7 +284,7 @@ class JamfPatchUploader(JamfUploaderBase):
                 return
 
         # Upload the patch
-        r = self.upload_patch(
+        _r = self.upload_patch(
             self.jamf_url,
             self.patch_name,
             self.patch_softwaretitle_id,

--- a/JamfUploaderProcessors/JamfPatchUploader.py
+++ b/JamfUploaderProcessors/JamfPatchUploader.py
@@ -1,0 +1,322 @@
+#!/usr/local/autopkg/python
+
+"""
+JamfPatchUploader processor for uploading a patch policy to Jamf Pro using AutoPkg
+    by Marcel Keßler based on G Pugh's great work
+"""
+
+import os.path
+import sys
+import xml.etree.cElementTree as ET
+
+from time import sleep
+from autopkglib import ProcessorError  # pylint: disable=import-error
+
+# to use a base module in AutoPkg we need to add this path to the sys.path.
+# this violates flake8 E402 (PEP8 imports) but is unavoidable, so the following
+# imports require noqa comments for E402
+sys.path.insert(0, os.path.dirname(__file__))
+
+from JamfUploaderLib.JamfUploaderBase import JamfUploaderBase  # noqa: E402
+
+__all__ = ["JamfPatchUploader"]
+
+
+class JamfPatchUploader(JamfUploaderBase):
+    """A processor for AutoPkg that will upload a patch policy to a Jamf Cloud or on-prem server."""
+
+    input_variables = {
+        "JSS_URL": {
+            "required": True,
+            "description": "URL to a Jamf Pro server that the API user has write access "
+            "to, optionally set as a key in the com.github.autopkg "
+            "preference file.",
+        },
+        "API_USERNAME": {
+            "required": True,
+            "description": "Username of account with appropriate access to "
+            "jss, optionally set as a key in the com.github.autopkg "
+            "preference file.",
+        },
+        "API_PASSWORD": {
+            "required": True,
+            "description": "Password of api user, optionally set as a key in "
+            "the com.github.autopkg preference file.",
+        },
+        "pkg_path": {
+            "required": False,
+            "description": "Path to a pkg or dmg to import - provided by "
+            "previous pkg recipe/processor.",
+            "default": "",
+        },
+        "version": {
+            "required": False,
+            "description": "Version string - provided by "
+            "previous pkg recipe/processor.",
+            "default": "",
+        },
+        "patch_softwaretitle": {
+            "required": True,
+            "description": "Name of the patch softwaretitel (e.g. 'Mozilla Firefox') used in Jamf. " +
+            "You need to create the patch softwaretitle by hand, since there is currently no way " +
+            "to craete these via the API.",
+            "default": "",
+        },
+        "patch_name": {
+            "required": False,
+            "description": "Name of the patch policy (e.g. 'Mozilla Firefox - 93.02.10'). " +
+            "If no name is provided defaults to '%patch_softwaretitle% - %version%'.",
+            "default": "",
+        },
+        "patch_template": {
+            "required": True,
+            "description": "XML-Template used for the patch policy.",
+            "default": "",
+        },
+        "patch_icon_policy_name": {
+            "required": False,
+            "description": "Name of an already existing (!) policy (not a patch policy). " +
+            "The icon of this policy will be extracted and can be used in the patch template " +
+            "with the variable `%patch_icon_id%`. There is currently no reasonable way to upload " +
+            "a custom icon for patch policies.",
+            "default": "",
+        },
+        "replace_patch": {
+            "required": False,
+            "description": "Overwrite an existing patch policy if True.",
+            "default": False,
+        },
+    }
+
+    output_variables = {
+        "patch": {"description": "The created/updated patch definition."},
+        "jamfpatchuploader_summary_result": {
+            "description": "Description of interesting results.",
+        },
+    }
+
+    def prepare_patch_template(self, patch_name, patch_template):
+        """
+        Prepares the patch template. Mostly copied from the policy processor.
+        """
+        if os.path.exists(patch_template):
+            with open(patch_template, "r") as file:
+                template_contents = file.read()
+        else:
+            raise ProcessorError("Patch template does not exist!")
+
+        patch_name = self.substitute_assignable_keys(patch_name)
+        self.env["patch_name"] = self.patch_name
+        template_contents = self.substitute_assignable_keys(
+            template_contents, xml_escape=True
+        )
+
+        self.output("Patch data:", verbose_level=2)
+        self.output(template_contents, verbose_level=2)
+
+        # write the template to temp file
+        template_xml = self.write_temp_file(template_contents)
+        return patch_name, template_xml
+
+    def upload_patch(
+            self, jamf_url, patch_name, patch_softwaretitle_id, patch_template, patch_id=0, enc_creds="", token="",
+    ):
+        """Uploads the patch policy"""
+        self.output("Uploading Patch policy...")
+
+        # For patch policies the url differs when creating a new one or updating one.
+        if patch_id:
+            object_type = "patch_policy"
+            url = "{}/{}/id/{}".format(jamf_url, self.api_endpoints(object_type), patch_id)
+        else:
+            object_type = "patch_policy_init"
+            url = "{}/{}/id/{}".format(jamf_url, self.api_endpoints(object_type), patch_softwaretitle_id)
+        self.output("URL: {}".format(url))
+
+        count = 0
+        while True:
+            count += 1
+            self.output("Patch upload attempt {}".format(count), verbose_level=2)
+            request = "PUT" if patch_id else "POST"
+            r = self.curl(
+                request=request,
+                url=url,
+                enc_creds=enc_creds,
+                token=token,
+                data=patch_template,
+            )
+            # check HTTP response
+            if self.status_check(r, "Patch", patch_name, request) == "break":
+                break
+            if count > 5:
+                self.output("WARNING: Patch policy upload did not succeed after 5 attempts")
+                self.output("\nHTTP POST Response Code: {}".format(r.status_code))
+                raise ProcessorError("ERROR: Policy upload failed.")
+            sleep(30)
+        return r
+
+
+    def main(self):
+        """Do the main thing here"""
+        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_user = self.env.get("API_USERNAME")
+        self.jamf_password = self.env.get("API_PASSWORD")
+        self.pkg_path = self.env.get("pkg_path")
+        self.version = self.env.get("version")
+        self.patch_softwaretitle = self.env.get("patch_softwaretitle")
+        self.patch_name = self.env.get("patch_name")
+        self.patch_template = self.env.get("patch_template")
+        self.patch_icon_policy_name = self.env.get("patch_icon_policy_name")
+        self.replace = self.env.get("replace_patch")
+        if not self.replace or self.replace == "False":
+            self.replace = False
+
+        # clear any pre-existing summary result
+        if "jamfpatchuploader_summary_result" in self.env:
+            del self.env["jamfpatchuploader_summary_result"]
+
+        if "/" not in self.patch_template:
+            found_template = self.get_path_to_file(self.patch_template)
+            if found_template:
+                self.patch_template = found_template
+            else:
+                raise ProcessorError(
+                    f"ERROR: Patch Template file {self.patch_template} not found"
+                )
+
+
+        self.output(f"Checking for existing '{self.patch_softwaretitle}' on {self.jamf_url}")
+
+        # obtain the relevant credentials
+        token, send_creds, _ = self.handle_classic_auth(
+            self.jamf_url, self.jamf_user, self.jamf_password
+        )
+
+        # -- Patch Icon
+        # Sadly there is currently no (reasonable) way to upload an icon for a patch policy.
+        # We can only upload icons for non-patch polcies, and use them in patch policies afterwards.
+        # Since most AutoPKG workflows include a policy (incl. an icon), we simply provide a way
+        # to extract the icon from a specified policy (if desired).
+
+        if self.patch_icon_policy_name:
+            obj_type = "policy"
+            obj_name = self.patch_icon_policy_name
+            self.patch_icon_policy_id = self.get_api_obj_id_from_name(
+                self.jamf_url, obj_name, obj_type, enc_creds=send_creds, token=token,
+            )
+        else:
+            self.patch_icon_policy_id = 0
+            self.output(
+                "No 'patch_icon_policy_name' was provided. Skipping icon extraction...",
+                verbose_level = 1
+            )
+
+        if self.patch_icon_policy_id and self.patch_icon_policy_name:
+            # Only try to extract an icon, if a policy with the given name was found.
+            obj_type = "policy"
+            obj_id = self.patch_icon_policy_id
+            obj_path = "self_service/self_service_icon/id"
+            self.patch_icon_id = self.get_api_obj_value_from_id(
+                self.jamf_url, obj_type, obj_id, obj_path, enc_creds=send_creds, token=token,
+            )
+        elif not self.patch_icon_policy_id and self.patch_icon_policy_name:
+            # Name was given, but no matching id could be found
+            self.output(
+                "No policy with the given name '{}' was found. ".format(self.patch_icon_policy_name) +
+                "Not able to extract an icon. Continuing..."
+            )
+
+        if self.patch_icon_id:
+            # Icon id could be extracted
+            self.output(
+                "Set 'patch_icon_id' to '{}'.".format(self.patch_icon_id),
+                verbose_level=2
+            )
+            # Convert int to str to avoid errors while mapping the template later on
+            self.env["patch_icon_id"] = str(self.patch_icon_id)
+        elif not self.patch_icon_id and self.patch_icon_policy_id:
+            # Found policy by name, but no icon id could  be extracted
+            self.output(
+                "WARNING: No icon found in given policy '{}'!".format(self.patch_icon_policy_name)
+            )
+
+
+        # -- Patch Softwaretitle
+        obj_type = "patch_software_title"
+        obj_name = self.patch_softwaretitle
+        self.patch_softwaretitle_id = self.get_api_obj_id_from_name(
+            self.jamf_url, obj_name, obj_type, enc_creds=send_creds, token=token,
+        )
+
+        if not self.patch_softwaretitle_id:
+            raise ProcessorError(f"ERROR: Couldn't find patch softwaretitle with name '{self.patch_softwaretitle}'. " +
+                                 "You need to create the patch softwaretitle by hand in Jamf Pro. " +
+                                 "There is currently no way to create a patch softwaretitle via API.")
+        self.env["patch_softwaretitle_id"] = self.patch_softwaretitle_id
+
+        # --- Patch Policy
+        if not self.patch_name:
+            self.patch_name = self.patch_softwaretitle + " - " + self.version
+            self.output(f"Set `patch_name` to '{self.patch_name}' since no name was provided.")
+
+        self.patch_template, patch_template_xml = self.prepare_patch_template(
+            self.patch_name, self.patch_template
+        )
+
+        obj_type = "patch_policy"
+        obj_name = self.patch_name
+        patch_id = self.get_api_obj_id_from_name(
+            self.jamf_url, obj_name, obj_type, enc_creds=send_creds, token=token,
+        )
+
+        if patch_id:
+            self.output(
+                "Patch '{}' already exists: ID {}".format(self.patch_name, patch_id)
+            )
+            if self.replace:
+                self.output(
+                    "Replacing existing patch as 'replace_patch' is set to {}".format(
+                        self.replace
+                    ),
+                    verbose_level=1,
+                )
+            else:
+                self.output(
+                    "Not replacing existing patch. Use replace_patch='True' to enforce.",
+                    verbose_level=1,
+                )
+                return
+
+        # Upload the patch
+        r = self.upload_patch(
+            self.jamf_url,
+            self.patch_name,
+            self.patch_softwaretitle_id,
+            patch_template=patch_template_xml,
+            patch_id=patch_id,
+            enc_creds=send_creds,
+            token=token,
+        )
+
+        # --- Summary
+        self.env["patch"] = self.patch_name
+        self.env["jamfpatchuploader_summary_result"] = {
+            "summary_text": "The following patch policies were created or updated in Jamf Pro:",
+            "report_fields": [
+                "patch_id",
+                "patch_policy_name",
+                "patch_softwaretitle",
+                "patch_version"
+            ],
+            "data": {
+                "patch_id": str(patch_id),
+                "patch_policy_name": self.patch_name,
+                "patch_softwaretitle": self.patch_softwaretitle,
+                "patch_version": self.version
+            },
+        }
+
+
+if __name__ == "__main__":
+    PROCESSOR = JamfPatchUploader()
+    PROCESSOR.execute_shell()

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -45,6 +45,9 @@ class JamfUploaderBase(Processor):
             "logflush": "JSSResource/logflush",
             "package": "JSSResource/packages",
             "package_upload": "dbfileupload",
+            "patch_policy": "JSSResource/patchpolicies",
+            "patch_policy_init": "JSSResource/patchpolicies/softwaretitleconfig",
+            "patch_software_title": "JSSResource/patchsoftwaretitles",
             "os_x_configuration_profile": "JSSResource/osxconfigurationprofiles",
             "policy": "JSSResource/policies",
             "policy_icon": "JSSResource/fileuploads/policies",
@@ -75,6 +78,8 @@ class JamfUploaderBase(Processor):
             "extension_attribute": "computer_extension_attributes",
             "os_x_configuration_profile": "os_x_configuration_profiles",
             "package": "packages",
+            "patch_policy": "patch_policies",
+            "patch_software_title": "patch_software_titles",
             "policy": "policies",
             "restricted_software": "restricted_software",
             "script": "scripts",
@@ -457,6 +462,8 @@ class JamfUploaderBase(Processor):
                 if obj["name"].lower() == object_name.lower():
                     obj_id = obj["id"]
             return obj_id
+        elif r.status_code == 401:
+            raise ProcessorError("ERROR: Jamf returned status code '401' - Access denied.")
 
     def substitute_assignable_keys(self, data, xml_escape=False):
         """substitutes any key in the inputted text using the %MY_KEY% nomenclature"""

--- a/JamfUploaderProcessors/READMEs/JamfPatchUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfPatchUploader.md
@@ -1,0 +1,39 @@
+# JamfPatchUploader
+
+## Description
+
+A processor for AutoPkg that will upload a Patch Policy to a Jamf Cloud or on-prem server.
+
+## Input variables
+
+- **JSS_URL:**
+  - **required:** True
+  - **description:** URL to a Jamf Pro server that the API user has write access to, optionally set as a key in the com.github.autopkg preference file.
+- **API_USERNAME:**
+  - **required:** True
+  - **description:** Username of account with appropriate access to jss, optionally set as a key in the com.github.autopkg preference file.
+- **API_PASSWORD:**
+  - **required:** True
+  - **description:** Password of api user, optionally set as a key in the com.github.autopkg preference file.
+- **patch_softwaretitle**:
+  - **required**: True
+  - **description**: Name of the patch softwaretitle (e.g. 'Mozilla Firefox') used in Jamf. You need to create the patch softwaretitle by hand, since there is currently no way to create these via the API.
+- **patch_name**:
+  - **required**: False
+  - **description**: Name of the patch policy (e.g. 'Mozilla Firefox - 93.02.10').
+  - **default**: '%patch_softwaretitle% - %version%'
+- **patch_template**:
+  - **required**: True
+  - **description**: XML-Template used for the patch policy.
+- **patch_icon_policy_name**:
+  - **required**: False
+  - **description**: Name of an already existing (!) policy (not a patch policy). The icon of this policy will be extracted and can be used in the patch template with the variable `%patch_icon_id%`. There is currently no reasonable way to upload a custom icon for patch policies.
+- **replace_patch**:
+  - **required**: False
+  - **description**: Overwrite an existing patch policy if True.
+  - **default**: False
+
+## Output variables
+
+- **jamfdockitemuploader_summary_result:**
+  - **description:** Description of interesting results.


### PR DESCRIPTION
Hi @grahampugh ,

like already mentioned by me in slack I wrote another Processor to upload Patch Polices to Jamf.

Sadly it's not possible to craete the Patch Softwaretitle via the API right now. This has to be done by hand. But after that, the processor can be used like every other one:

```yaml
Process:
  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPatchUploader
    Arguments:
      patch_softwaretitle: "Google Chrome"
      patch_template: "Patch_Tester_SS.xml"
      patch_icon_policy_name: "%POLICY_NAME%"
      replace_patch: True
```

It's possible to create 'Install automatically' (aka 'prompt') policies:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<patch_policy>
  <general>
    <name>%patch_name%</name>
    <enabled>false</enabled>
    <target_version>%version%</target_version>
    <distribution_method>prompt</distribution_method>
    <allow_downgrade>false</allow_downgrade>
    <patch_unknown>true</patch_unknown>
  </general>
  <scope>
    <all_computers>true</all_computers>
    <computers/>
    <computer_groups/>
    <users/>
    <buildings/>
    <departments/>
    <limitations>
      <network_segments/>
      <ibeacons/>
    </limitations>
    <exclusions>
      <computers/>
      <computer_groups/>
      <users/>
      <buildings/>
      <departments/>
      <network_segments/>
      <ibeacons/>
    </exclusions>
  </scope>
  <user_interaction>
    <grace_period>
      <grace_period_duration>240</grace_period_duration>
      <notification_center_subject>Update</notification_center_subject>
      <message>$APP_NAMES wird in $DELAY_MINUTES Minuten beendet, um $SOFTWARE_TITLE zu aktualisiert. Speichere alle Dokumente und beende die genannten Programme!</message>
    </grace_period>
  </user_interaction>
  <software_title_configuration_id>%patch_softwaretitle_id%</software_title_configuration_id>
</patch_policy>
```
and 'Self Service' Patch Policies including an icon:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<patch_policy>
  <general>
    <name>%patch_name%</name>
    <enabled>false</enabled>
    <target_version>%version%</target_version>
    <distribution_method>selfservice</distribution_method>
    <allow_downgrade>false</allow_downgrade>
    <patch_unknown>true</patch_unknown>
  </general>
  <scope>
    <all_computers>true</all_computers>
    <computers/>
    <computer_groups/>
    <users/>
    <buildings/>
    <departments/>
    <limitations>
      <network_segments/>
      <ibeacons/>
    </limitations>
    <exclusions>
      <computers/>
      <computer_groups/>
      <users/>
      <buildings/>
      <departments/>
      <network_segments/>
      <ibeacons/>
    </exclusions>
  </scope>
  <user_interaction>
      <install_button_text>Update</install_button_text>
      <self_service_description/>
      <self_service_icon>
        <id>%patch_icon_id%</id>
      </self_service_icon>
      <notifications>
        <notification_enabled>true</notification_enabled>
        <notification_type>Self Service and Notification Center</notification_type>
        <notification_subject>Google Chrome update available</notification_subject>
        <notification_message/>
        <reminders>
          <notification_reminders_enabled>true</notification_reminders_enabled>
          <notification_reminder_frequency>1</notification_reminder_frequency>
        </reminders>
      </notifications>
      <deadlines>
        <deadline_enabled>false</deadline_enabled>
        <deadline_period>7</deadline_period>
      </deadlines>
  </user_interaction>
  <software_title_configuration_id>%patch_softwaretitle_id%</software_title_configuration_id>
</patch_policy>
```

Note that the variables `patch_softwaretitle_id` and `patch_icon_id` need to be used in the templates. 

As an fitting icon workflow I decided for the following:
- If `patch_icon_policy_name` no icon gets extracted, but the processor continues. If no `patch_icon_id` is mentioned in the template, simply a patch without any icon get's created.
- If a user want's to use a custom icon, he can simply name a existing policy, from which the icon get's extracted.
- If the user want's to use the icon of the policy which got uploaded beforehand in the same recipe (I guess this is probably the main usecase anyway), he can simply use the policy name variable e.g. `patch_icon_policy_name: "%POLICY_NAME%"`.

I needed to append some entries to the JamfUploaderBase (api_endpoints, ...) and also included a small if-clause if a user is not authorized to use the api (which probably happens if the user first runs this processor ;)).

Hope everything is fine!

Cheers