### PR TITLE
Added process to link pkg in patch softwaretitles

### DIFF
--- a/JamfUploaderProcessors/JamfPatchUploader.py
+++ b/JamfUploaderProcessors/JamfPatchUploader.py
@@ -233,12 +233,17 @@ class JamfPatchUploader(JamfUploaderBase):
         self.output("Uploading Patch policy...")
 
         # For patch policies the url differs when creating a new one or updating one.
+        object_type = "patch_policy"
         if patch_id:
-            object_type = "patch_policy"
-            url = "{}/{}/id/{}".format(jamf_url, self.api_endpoints(object_type), patch_id)
+            url = "{}/{}/id/{}".format(
+                jamf_url, self.api_endpoints(object_type), patch_id
+            )
         else:
-            object_type = "patch_policy_init"
-            url = "{}/{}/id/{}".format(jamf_url, self.api_endpoints(object_type), patch_softwaretitle_id)
+            url = "{}/{}/softwaretitleconfig/id/{}".format(
+                jamf_url,
+                self.api_endpoints(object_type),
+                patch_softwaretitle_id
+            )
 
         count = 0
         while True:

--- a/JamfUploaderProcessors/JamfPatchUploader.py
+++ b/JamfUploaderProcessors/JamfPatchUploader.py
@@ -365,7 +365,7 @@ class JamfPatchUploader(JamfUploaderBase):
                 )
             )
 
-        # -- Patch Softwaretitle
+        # Patch Softwaretitle
         obj_type = "patch_software_title"
         obj_name = self.patch_softwaretitle
         self.patch_softwaretitle_id = self.get_api_obj_id_from_name(
@@ -401,7 +401,7 @@ class JamfPatchUploader(JamfUploaderBase):
             token
         )
 
-        # --- Patch Policy
+        # Patch Policy
         if not self.patch_name:
             self.patch_name = self.patch_softwaretitle + " - " + self.version
             self.output(
@@ -458,7 +458,7 @@ class JamfPatchUploader(JamfUploaderBase):
         except ET.ParseError as xml_error:
             raise ProcessorError from xml_error
 
-        # --- Summary
+        # Summary
         self.env["patch"] = self.patch_name
         self.env["jamfpatchuploader_summary_result"] = {
             "summary_text": "The following patch policies were created or updated in Jamf Pro:",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -230,7 +230,14 @@ class JamfUploaderBase(Processor):
         return tmp_dir
 
     def curl(
-        self, request="", url="", token="", enc_creds="", data="", additional_headers=""
+            self,
+            request="",
+            url="",
+            token="",
+            enc_creds="",
+            data="",
+            additional_headers="",
+            force_xml=False
     ):
         """
         build a curl command based on method (GET, PUT, POST, DELETE)
@@ -274,7 +281,13 @@ class JamfUploaderBase(Processor):
 
         # Accept for GET requests
         if request == "GET" or request == "DELETE":
-            curl_cmd.extend(["--header", "Accept: application/json"])
+            # Some endpoints are exceptions which NEED to respond with xml
+            # Otherwise the endpoints are broken or don't report all information.
+            # For example the `patchsoftwaretitle` endpoint.
+            if force_xml:
+                curl_cmd.extend(["--header", "Accept: application/xml"])
+            else:
+                curl_cmd.extend(["--header", "Accept: application/json"])
 
         # icon upload requires special method
         elif request == "POST" and "fileuploads" in url:


### PR DESCRIPTION
Hi @grahampugh ,

as discussed my processor was not fully fledged and I simply missed that because of bad testing practices. Sorry again for that!

To link packages to the fitting version in the patch softwaretitle I sadly needed to inlcude the XML library again. The xml response of `/patchsoftwaretitles` is pretty complex and I didn't found a reliable way to remove the version from the response, since the `package` element could be empty (e.g. `<package/>`) or prefilled with a different version (e.g. `<version><software_version><package><name>abc.pkg</name><id>123</id></package></software_version></version>`). 

Also I needed to make the discussed change to the curl function.

I had to cherry pick your already made changes to the Processor, and I hope I didn't miss anything. :) 