### PR TITLE
Fix for insecure flag

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -359,7 +359,7 @@ class JamfUploaderBase(Processor):
                 )
         # insecure mode
         if self.env.get("insecure_mode"):
-            curl_cmd.insert(0, "--insecure")
+            curl_cmd.insert(1, "--insecure")
         # additional headers for advanced requests
         if additional_headers:
             curl_cmd.extend(additional_headers)


### PR DESCRIPTION
Fixes insecure_modes injection point. Not sure if something changed in the curl_cmd or just me being a doofus, but it's currently putting --insecure before curl creating an unusable option. This fixes that.