### PR TITLE
Add the global variable NAME to the summary result (report plist)  

### DIFF
--- a/JamfUploaderProcessors/JamfPackageUploader.py
+++ b/JamfUploaderProcessors/JamfPackageUploader.py
@@ -901,12 +901,13 @@ class JamfPackageUploader(JamfUploaderBase):
         if self.pkg_metadata_updated or self.pkg_uploaded:
             self.env["jamfpackageuploader_summary_result"] = {
                 "summary_text": "The following packages were uploaded to or updated in Jamf Pro:",
-                "report_fields": ["pkg_path", "pkg_name", "version", "category"],
+                "report_fields": ["category", "name", "pkg_name", "pkg_path", "version"],
                 "data": {
-                    "pkg_path": self.pkg_path,
-                    "pkg_name": self.pkg_name,
-                    "version": self.version,
                     "category": self.pkg_category,
+                    "name": self.env.get("NAME"),
+                    "pkg_name": self.pkg_name,
+                    "pkg_path": self.pkg_path,
+                    "version": self.version,
                 },
             }
 


### PR DESCRIPTION
For some automation processes it can be useful to get the name of the current product within the report plist part of the JamfPackageUploader. (Like JSSImporter)

We use these variables to send notifications if a new package was uploaded via our Gitlab CI wrapper script. The notification processors are currently not the right way for us. 
However, the variable does not bother if it is not needed.