### PR TITLE
Feature:  Method to exclude specific keys from XML Escape

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -518,7 +518,7 @@ class JamfUploaderBase(Processor):
                 "ERROR: Jamf returned status code '401' - Access denied."
             )
 
-    def substitute_assignable_keys(self, data, xml_escape=False):
+    def substitute_assignable_keys(self, data, xml_escape=False, no_xml_escape=[]):
         """substitutes any key in the inputted text using the %MY_KEY% nomenclature"""
         # do a four-pass to ensure that all keys are substituted
         loop = 5
@@ -537,7 +537,7 @@ class JamfUploaderBase(Processor):
                         ),
                         verbose_level=2,
                     )
-                    if xml_escape:
+                    if xml_escape and found_key not in no_xml_escape:
                         replacement_key = escape(self.env.get(found_key))
                     else:
                         replacement_key = self.env.get(found_key)


### PR DESCRIPTION
I have a custom processor where I generate XML and store it in an AutoPkg env variable that I want to insert into my Policy Template on on each AutoPkg run.  Since this data is XML, during the JamfUploader process, it will escape it instead so it is not interpreted as _actual_ XML.

You have the option already too or not to escape XML in the `substitute_assignable_keys` function.  This feature simply provides a way for the user to specify keys that should not be escaped via either:
* a list (e.g. provided in the recipe or a AutoPkg preference file)
* a string (e.g. when running `autopkg run <recipe_id> --key "JAMF_NO_XML_ESCAPE=XML_VARIABLE"`)