### PR TITLE
Allow empty strings for variable substitution

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -529,7 +529,7 @@ class JamfUploaderBase(Processor):
                 break
             found_keys = [i.replace("%", "") for i in found_keys]
             for found_key in found_keys:
-                if self.env.get(found_key):
+                if self.env.get(found_key) is not None:
                     self.output(
                         (
                             f"Replacing any instances of '{found_key}' with",


### PR DESCRIPTION
Allow empty strings (`""`) to be valid values for variable substitution.

I believe empty strings (`""`) should be allowed, to be able to override a parent value that you may not want sent, but do not have a desired setting.  Historically, I've used this practice to override numbers variables, for example, with the `os_requirements` key.

With this change, if the variable is present in the recipe/override, it will not raise an error, however, if it is not present, it will raise an error as it does now.