### PR TITLE
Explicitly print not substitutable key

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -546,7 +546,7 @@ class JamfUploaderBase(Processor):
                     self.output(
                         f"WARNING: '{found_key}' has no replacement object!",
                     )
-                    raise ProcessorError(f"Unsubstitutable key in template found:  '{found_key}'")
+                    raise ProcessorError(f"Unsubstitutable key in template found: '{found_key}'")
         return data
 
     def substitute_limited_assignable_keys(

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -546,7 +546,7 @@ class JamfUploaderBase(Processor):
                     self.output(
                         f"WARNING: '{found_key}' has no replacement object!",
                     )
-                    raise ProcessorError("Unsubstitutable key in template found")
+                    raise ProcessorError(f"Unsubstitutable key in template found:  '{found_key}'")
         return data
 
     def substitute_limited_assignable_keys(


### PR DESCRIPTION
The key that is not substitutable is printed out before as a `self.output("Warning: [...]")`, but is not identified in the raised error.  This simply also includes the key in the raised error.

I have a wrapper around my `autopkg run`'s and it gets the `RecipeError` key, which ends up not providing what the Processor actually errored out on.