### PR TITLE
Fix the `--output` option from being passed twice

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -305,22 +305,18 @@ class JamfUploaderBase(Processor):
         # Jamf Pro API authentication
         if enc_creds:
             curl_cmd.extend(["--header", f"authorization: Basic {enc_creds}"])
-            curl_cmd.extend(["--output", output_file])
         elif token:
             curl_cmd.extend(["--header", f"authorization: Bearer {token}"])
-            curl_cmd.extend(["--output", output_file])
 
         # icon download
         if request == "GET" and "ics.services.jamfcloud.com" in url:
             output_file = os.path.join(tmp_dir, "icon_download.png")
-            curl_cmd.extend(["--output", output_file])
 
         # 'Accept' for GET and DELETE requests
         # By default, we obtain json as its easier to parse. However,
         # some endpoints (For example the 'patchsoftwaretitle' endpoint)
         # do not return complete json, so we have to get the xml instead.
         elif request == "GET" or request == "DELETE":
-            curl_cmd.extend(["--output", output_file])
             if "legacy/packages" not in url:
                 if force_xml:
                     curl_cmd.extend(["--header", "Accept: application/xml"])
@@ -339,7 +335,6 @@ class JamfUploaderBase(Processor):
 
         # Content-Type for POST/PUT
         elif request == "POST" or request == "PUT":
-            curl_cmd.extend(["--output", output_file])
             if data and "slack" in url or "webhook.office" in url:
                 # slack and teams require a data argument
                 curl_cmd.extend(["--data", data])
@@ -356,6 +351,8 @@ class JamfUploaderBase(Processor):
             # note: other endpoints should supply their headers via 'additional_headers'
         elif request != "GET" and request != "DELETE":
             self.output(f"WARNING: HTTP method {request} not supported")
+
+        curl_cmd.extend(["--output", output_file])
 
         # write session for jamf requests
         if (


### PR DESCRIPTION
The `--output <output_file>` option was being added to the `curl` statement multiple times.  This prevents that.

Example:

```
JamfPolicyUploader: Checking for existing 'Firefox' on <https://jps.org:8443>
JamfPolicyUploader: Checking for existing authentication token
JamfPolicyUploader: Checking <https://jps.org:8443> against <https://jps.org:8443>
JamfPolicyUploader: URL and user for token matches current request
JamfPolicyUploader: Existing token is valid
JamfPolicyUploader: curl command: /usr/bin/curl --dump-header /tmp/jamf_upload/curl_headers_from_jamf_upload.txt <https://jps.org:8443>/api/v1/jamf-pro-version --request GET --silent --show-error --header authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRoZW50aWNhdGVkLWFwcCI6IkdFTkVSSUMiLCJhdXRoZW50aWNhdGlvbi10eXBlIjoiSlNTIiwiZ3JvdXBzIjpbXSwic3ViamVjdC10eXBlIjoiSlNTX1VTRVJfSUQiLCJ0b2tlbi11dWlkIjoiZDBhODBiZjYtOTg0MS00NzczLWI5ZTEtMTY2MmI3MmRhMjE1IiwibGRhcC1zZXJ2ZXItaWQiOi0xLCJzdWIiOiI0OCIsImV4cCI6MTY2NDQwNjcxMX0.YWW1v1qSO8TIaJvV7T1CkYwgezAV9NZUUHxJg_HSXgc --output /tmp/jamf_upload/curl_output_from_jamf_upload.txt --output /tmp/jamf_upload/curl_output_from_jamf_upload.txt --header Accept: application/json --cookie-jar /tmp/jamf_upload/curl_cookies_from_jamf_upload.txt --cookie /tmp/jamf_upload/curl_cookies_from_jamf_upload.txt
```