### PR TITLE
(Properly Fix) Raise error if unable to determine version of Jamf Pro

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -462,17 +462,21 @@ class JamfUploaderBase(Processor):
                 jamf_pro_version = str(r.output["version"])
                 self.output(f"Jamf Pro Version: {jamf_pro_version}")
                 return jamf_pro_version
-            except (KeyError, AttributeError) as error:
+            except KeyError as error:
                 self.output(f"ERROR: No version received.  Error:\n{error}")
-                raise ProcessorError("Unable to determine version of Jamf Pro") from error
+                raise ProcessorError("No version received") from error
 
     def validate_jamf_pro_version(self, jamf_url, token):
         """return true if Jamf Pro version is 10.35 or greater"""
         jamf_pro_version = self.get_jamf_pro_version(jamf_url, token)
-        if APLooseVersion(jamf_pro_version) >= APLooseVersion("10.35.0"):
-            return True
-        else:
-            return False
+        try:
+            if APLooseVersion(jamf_pro_version) >= APLooseVersion("10.35.0"):
+                return True
+            else:
+                return False
+        except AttributeError as error:
+            self.output(f"ERROR: Unable to determine version of Jamf Pro.  Error:\n{error}")
+            raise ProcessorError("Unable to determine version of Jamf Pro") from error
 
     def get_uapi_obj_id_from_name(self, jamf_url, object_type, object_name, token):
         """Get the Jamf Pro API object by name. This requires use of RSQL filtering"""


### PR DESCRIPTION
Proper fix for PR #80.  I put that fix in the wrong location, my bad.

If JamfUploader is unable to determine the Jamf Pro version, `None` is returned and is attempted to be compared, which results in the following error that doesn't make it obvious where the issue _actually_ lies:
`Error: 'APLooseVersion' object has no attribute 'version'`

Here's a sanitized -vvv run with the stack trace:

```python
JamfPolicyUploader: Checking for existing 'Firefox' on <https://jps.org:8443>
JamfPolicyUploader: Checking for existing authentication token
JamfPolicyUploader: Checking <https://jps.org:8443> against <https://jps.org:8443>
JamfPolicyUploader: URL and user for token matches current request
JamfPolicyUploader: Existing token is valid
JamfPolicyUploader: curl command: /usr/bin/curl --dump-header /tmp/jamf_upload/curl_headers_from_jamf_upload.txt <https://jps.org:8443>/api/v1/jamf-pro-version --request GET --silent --show-error --header authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRoZW50aWNhdGVkLWFwcCI6IkdFTkVSSUMiLCJhdXRoZW50aWNhdGlvbi10eXBlIjoiSlNTIiwiZ3JvdXBzIjpbXSwic3ViamVjdC10eXBlIjoiSlNTX1VTRVJfSUQiLCJ0b2tlbi11dWlkIjoiZDBhODBiZjYtOTg0MS00NzczLWI5ZTEtMTY2MmI3MmRhMjE1IiwibGRhcC1zZXJ2ZXItaWQiOi0xLCJzdWIiOiI0OCIsImV4cCI6MTY2NDQwNjcxMX0.YWW1v1qSO8TIaJvV7T1CkYwgezAV9NZUUHxJg_HSXgc --output /tmp/jamf_upload/curl_output_from_jamf_upload.txt --output /tmp/jamf_upload/curl_output_from_jamf_upload.txt --header Accept: application/json --cookie-jar /tmp/jamf_upload/curl_cookies_from_jamf_upload.txt --cookie /tmp/jamf_upload/curl_cookies_from_jamf_upload.txt
JamfPolicyUploader: ERROR: No version received
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 626, in process
    self.main()
  File "/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/JamfUploaderProcessors/JamfPolicyUploader.py", line 292, in main
    token, send_creds, _ = self.handle_classic_auth(
  File "/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py", line 216, in handle_classic_auth
    if self.validate_jamf_pro_version(url, token):
  File "/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py", line 469, in validate_jamf_pro_version
    if APLooseVersion(jamf_pro_version) >= APLooseVersion("10.35.0"):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 954, in __ge__
    return self._compare(other) >= 0
  File "/Library/AutoPkg/autopkglib/__init__.py", line 911, in _compare
    max_length = max(len(self.version), len(other.version))
AttributeError: 'APLooseVersion' object has no attribute 'version'
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
Receipt written to /Library/AutoPkg/Cache/local.Firefox/receipts/local.Firefox-receipt-20220928-160241.plist

The following recipes failed:
    local.Firefox
        Error in local.Firefox: Processor: com.github.grahampugh.jamf-upload.processors/JamfPolicyUploader: Error: 'APLooseVersion' object has no attribute 'version'
```


I believe this is caused by a concurrency issue that I've been trying to track down and will submit a PR for.