### PR TITLE
JamfPatchUploader: Make upload of patch policy optional

### DIFF
--- a/JamfUploaderProcessors/JamfComputerProfileUploader.py
+++ b/JamfUploaderProcessors/JamfComputerProfileUploader.py
@@ -416,25 +416,6 @@ class JamfComputerProfileUploader(JamfUploaderBase):
                 organization = mobileconfig_contents["PayloadOrganization"]
             except KeyError:
                 organization = ""
-            try:
-                mobileconfig_identifier = mobileconfig_contents["PayloadIdentifier"]
-            except KeyError:
-                raise ProcessorError(
-                    "ERROR: Invalid mobileconfig file supplied - no PayloadIdentifier in file found"
-                )
-
-            # Check if PayloadIdentifier matches supplied Identifier
-            if not self.identifier:
-                self.output(f"WARNING: Recommended to provide `identifier` in recipe, to check if `PayloadIdentifier` "
-                            "of the mobileconfig file changed to avoid deployment problems!")
-            else:
-                if self.identifier == mobileconfig_identifier:
-                    self.output(f"Provided identifier '{self.identifier}' also found in mobileconfig. Continue...")
-                else:
-                    raise ProcessorError(
-                        f"ERROR: PayloadIdentifier '{mobileconfig_identifier}' in mobileconfig does not match recipe " \
-                            "provided identifier '{self.identifier}'! Aborting to avoid duplicate profile deployment"
-                    )
 
         # otherwise we are dealing with a payload plist and we need a few other bits of info
         else:

--- a/JamfUploaderProcessors/JamfComputerProfileUploader.py
+++ b/JamfUploaderProcessors/JamfComputerProfileUploader.py
@@ -416,6 +416,25 @@ class JamfComputerProfileUploader(JamfUploaderBase):
                 organization = mobileconfig_contents["PayloadOrganization"]
             except KeyError:
                 organization = ""
+            try:
+                mobileconfig_identifier = mobileconfig_contents["PayloadIdentifier"]
+            except KeyError:
+                raise ProcessorError(
+                    "ERROR: Invalid mobileconfig file supplied - no PayloadIdentifier in file found"
+                )
+
+            # Check if PayloadIdentifier matches supplied Identifier
+            if not self.identifier:
+                self.output(f"WARNING: Recommended to provide `identifier` in recipe, to check if `PayloadIdentifier` "
+                            "of the mobileconfig file changed to avoid deployment problems!")
+            else:
+                if self.identifier == mobileconfig_identifier:
+                    self.output(f"Provided identifier '{self.identifier}' also found in mobileconfig. Continue...")
+                else:
+                    raise ProcessorError(
+                        f"ERROR: PayloadIdentifier '{mobileconfig_identifier}' in mobileconfig does not match recipe " \
+                            "provided identifier '{self.identifier}'! Aborting to avoid duplicate profile deployment"
+                    )
 
         # otherwise we are dealing with a payload plist and we need a few other bits of info
         else:

--- a/JamfUploaderProcessors/READMEs/JamfPatchUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfPatchUploader.md
@@ -23,8 +23,8 @@ A processor for AutoPkg that will upload a Patch Policy to a Jamf Cloud or on-pr
   - **description**: Name of the patch policy (e.g. 'Mozilla Firefox - 93.02.10').
   - **default**: '%patch_softwaretitle% - %version%'
 - **patch_template**:
-  - **required**: True
-  - **description**: XML-Template used for the patch policy.
+  - **required**: False
+  - **description**: XML-Template used for the patch policy. If none is provided, only the installer will be linked to the corresponding version and no patch policy will be created.
 - **patch_icon_policy_name**:
   - **required**: False
   - **description**: Name of an already existing (!) policy (not a patch policy). The icon of this policy will be extracted and can be used in the patch template with the variable `%patch_icon_id%`. There is currently no reasonable way to upload a custom icon for patch policies.


### PR DESCRIPTION
Like requested in https://github.com/grahampugh/jamf-upload/issues/63 there are patching workflows without the need for constant up to date patch policies.

In this case only the patch definitions (installer versions) should be automatically linked. The final patch policy to deploy the patch to the clients will be managed by hand. This is useful for admins who want more control over the deployed version.

This patch doesn't brake any existing workflows nor does it add a new variable. If no patch template is provided, no patch policy will be created. The user get's informed about this behavior, and it's also addressed in the summary:

```
[...]
JamfPatchUploader: No patch template provided. Patch creation will be skipped and only installers will be linked.
[...]

The following patch policies were created or updated in Jamf Pro:
    Patch Id  Patch Policy Name               Patch Softwaretitle  Patch Version
    --------  -----------------               -------------------  -------------
    0         Not created - missing template  Mozilla Firefox      107.0.1
```

I've updated also the README. I hope it's okay to create a direct pull request :)