### PR TITLE
Added 'skip_script_key_substitution' Flag 

### DIFF
--- a/JamfUploaderProcessors/JamfScriptUploader.py
+++ b/JamfUploaderProcessors/JamfScriptUploader.py
@@ -7,8 +7,8 @@ JamfScriptUploader processor for uploading items to Jamf Pro using AutoPkg
 
 import os.path
 import sys
-
 from time import sleep
+
 from autopkglib import ProcessorError  # pylint: disable=import-error
 
 # to use a base module in AutoPkg we need to add this path to the sys.path.
@@ -117,6 +117,11 @@ class JamfScriptUploader(JamfUploaderBase):
             "description": "Script parameter 11 title",
             "default": "",
         },
+        "script_is_template": {
+            "required": False,
+            "description": "Process the script for user-defined substituations.",
+            "default": True,
+        },
         "replace_script": {
             "required": False,
             "description": "Overwrite an existing script if True.",
@@ -158,6 +163,7 @@ class JamfScriptUploader(JamfUploaderBase):
         script_parameter10,
         script_parameter11,
         script_os_requirements,
+        script_is_template,
         token,
         obj_id=0,
     ):
@@ -171,7 +177,8 @@ class JamfScriptUploader(JamfUploaderBase):
             raise ProcessorError("Script does not exist!")
 
         # substitute user-assignable keys
-        script_contents = self.substitute_assignable_keys(script_contents)
+        if script_is_template:
+            script_contents = self.substitute_assignable_keys(script_contents)
 
         # priority has to be in upper case. Let's make it nice for the user
         if script_priority:
@@ -259,11 +266,14 @@ class JamfScriptUploader(JamfUploaderBase):
         self.script_parameter9 = self.env.get("script_parameter9")
         self.script_parameter10 = self.env.get("script_parameter10")
         self.script_parameter11 = self.env.get("script_parameter11")
+        self.script_is_template = self.env.get("script_is_template")
         self.replace = self.env.get("replace_script")
         self.sleep = self.env.get("sleep")
         # handle setting replace in overrides
         if not self.replace or self.replace == "False":
             self.replace = False
+        if not self.script_is_template or self.script_is_template == "False":
+            self.script_is_template = False
 
         # clear any pre-existing summary result
         if "jamfscriptuploader_summary_result" in self.env:
@@ -364,6 +374,7 @@ class JamfScriptUploader(JamfUploaderBase):
             self.script_parameter10,
             self.script_parameter11,
             self.osrequirements,
+            self.script_is_template,
             token,
             obj_id,
         )

--- a/JamfUploaderProcessors/JamfScriptUploader.py
+++ b/JamfUploaderProcessors/JamfScriptUploader.py
@@ -117,10 +117,10 @@ class JamfScriptUploader(JamfUploaderBase):
             "description": "Script parameter 11 title",
             "default": "",
         },
-        "script_is_template": {
+        "skip_script_key_substitution": {
             "required": False,
-            "description": "Process the script for user-defined substituations.",
-            "default": True,
+            "description": "Skip key substitution in processing the script",
+            "default": False,
         },
         "replace_script": {
             "required": False,
@@ -163,7 +163,7 @@ class JamfScriptUploader(JamfUploaderBase):
         script_parameter10,
         script_parameter11,
         script_os_requirements,
-        script_is_template,
+        skip_script_key_substitution,
         token,
         obj_id=0,
     ):
@@ -176,8 +176,8 @@ class JamfScriptUploader(JamfUploaderBase):
         else:
             raise ProcessorError("Script does not exist!")
 
-        # substitute user-assignable keys
-        if script_is_template:
+        if not skip_script_key_substitution:
+            # substitute user-assignable keys
             script_contents = self.substitute_assignable_keys(script_contents)
 
         # priority has to be in upper case. Let's make it nice for the user
@@ -266,14 +266,14 @@ class JamfScriptUploader(JamfUploaderBase):
         self.script_parameter9 = self.env.get("script_parameter9")
         self.script_parameter10 = self.env.get("script_parameter10")
         self.script_parameter11 = self.env.get("script_parameter11")
-        self.script_is_template = self.env.get("script_is_template")
+        self.skip_script_key_substitution = self.env.get("skip_script_key_substitution")
         self.replace = self.env.get("replace_script")
         self.sleep = self.env.get("sleep")
         # handle setting replace in overrides
         if not self.replace or self.replace == "False":
             self.replace = False
-        if not self.script_is_template or self.script_is_template == "False":
-            self.script_is_template = False
+        if not self.skip_script_key_substitution or self.skip_script_key_substitution == "False":
+            self.skip_script_key_substitution = False
 
         # clear any pre-existing summary result
         if "jamfscriptuploader_summary_result" in self.env:
@@ -374,7 +374,7 @@ class JamfScriptUploader(JamfUploaderBase):
             self.script_parameter10,
             self.script_parameter11,
             self.osrequirements,
-            self.script_is_template,
+            self.skip_script_key_substitution,
             token,
             obj_id,
         )


### PR DESCRIPTION
This flag indicates if the script being uploaded is or isn't a template. If the flag is set to `False`, it'll skip the `substitute_assignable_keys(script_contents)` call. This can be useful for scripts that have strings bracketed by % symbols. For example, this `date` command in a bash script: `date +"%Y-%m-%d %H:%M:%S%z"`. Without this flag, JamfScriptUploader.py throws an `autopkglib.ProcessorError` exception saying, "Unsubstitutable key in template found: 'S'." This small example can be [worked around](https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-Tips,-Tricks,-FAQs#how-do-i-handle-importing-a-script-that-genuinely-has-percent-signs-in-it), but in larger or more pathological cases, it might be simpler to bypass the variable-replacement entirely.

The `script_is_template` flag is not required, and the default value is `True`. This should ensure that the default behavior of JamfScriptUploader.py doesn't change with this PR applied. (Or at least it shouldn't.) 

(Side note: I'm new to creating GH PRs, so apologies if the formatting is messed up somehow.) 