### PR TITLE
Allows skipping upload of group/policy if template is explicitly 'False'

### DIFF
--- a/JamfUploaderProcessors/JamfComputerGroupUploader.py
+++ b/JamfUploaderProcessors/JamfComputerGroupUploader.py
@@ -161,6 +161,17 @@ class JamfComputerGroupUploader(JamfUploaderBase):
             del self.env["jamfcomputergroupuploader_summary_result"]
         group_uploaded = False
 
+        if self.computergroup_template == "False":
+            self.env['group_uploaded'] = False
+            self.output(
+                "Skipping '{}' group as 'computergroup_template' is set to '{}'".format(
+                    self.computergroup_name,
+                    self.computergroup_template
+                ),
+                verbose_level=1,
+            )
+            return 0
+
         # handle files with a relative path
         if not self.computergroup_template.startswith("/"):
             found_template = self.get_path_to_file(self.computergroup_template)

--- a/JamfUploaderProcessors/JamfPolicyUploader.py
+++ b/JamfUploaderProcessors/JamfPolicyUploader.py
@@ -270,6 +270,17 @@ class JamfPolicyUploader(JamfUploaderBase):
         if "jamfpolicyuploader_summary_result" in self.env:
             del self.env["jamfpolicyuploader_summary_result"]
 
+        if self.policy_template == "False":
+            self.env['policy_uploaded'] = False
+            self.output(
+                "Skipping '{}' policy as 'policy_template' is set to '{}'".format(
+                    self.policy_name,
+                    self.policy_template
+                ),
+                verbose_level=1,
+            )
+            return 0
+
         # handle files with a relative path
         if not self.policy_template.startswith("/"):
             found_template = self.get_path_to_file(self.policy_template)


### PR DESCRIPTION
The processor `StopProcessingIf` is useful if one wants to stop processing if a certain condition exists, but isn't as handy if you want the rest of the recipe process to proceed **except** a particular step.

This change would allow a recipe to be written with multiple groups and policies, optionally skipping one or more based on `Input` dictionary values, or more importantly, based on those values in an override.

In my specific use case, a custom processor is being used to evaluate a list of 'allowed' and 'required' group names obtained via recipe `Input`, write custom group (using that criteria) and policy templates, then output the relevant values for use in `JamfComputerGroupUploader` and `JamfPolicyUploader`.  With this change the processors are then be able to upload _or skip_ the relevant groups and policies; this has cut down the complexity of our recipes and reduced the number of templates needed.

For simplicity, I evaluated the existing `computergroup_template` and `policy_template` arguments.  Alternatively, a new argument could be added, if this was thought to be a better approach.