### PR TITLE
dry_run argument added to JamfPackageCleaner

### DIFF
--- a/JamfUploaderProcessors/READMEs/JamfPackageCleaner.md
+++ b/JamfUploaderProcessors/READMEs/JamfPackageCleaner.md
@@ -30,6 +30,10 @@ A processor for AutoPkg that will remove packages matching a pattern from a Jamf
   - **required**: False
   - **description**: The maximum number of packages that can be deleted. This is used as a failsafe.
   - **default**: 20
+- **dry_run**:
+  - **required**: False
+  - **description**: If set to True, nothing is deleted from Jamf Pro. Use together with `-v` for detailed information. This is used for testing
+  - **default**: False
 
 ## Output variables
 


### PR DESCRIPTION
An optional `dry_run` argument has been added. 

If `--key dry_run=True`, nothing will be deleted from Jamf Pro. Use together with `-v` to see a list of intended package actions.

```
autopkg run -v Awesome_App.jamf --post com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner --key dry_run=True

...
JamfPackageCleaner: ✅ Awesome_App-30.0.pkg
JamfPackageCleaner: ✅ Awesome_App-29.0.pkg
JamfPackageCleaner: ✅ Awesome_App-28.0.pkg
JamfPackageCleaner: ❌ Awesome_App-27.0.pkg (will be deleted)
JamfPackageCleaner: ❌ Awesome_App-26.0.pkg (will be deleted)
JamfPackageCleaner: ❌ Awesome_App-25.0.pkg (will be deleted)
JamfPackageCleaner: ❌ Awesome_App-24.0.pkg (will be deleted)
JamfPackageCleaner: INFO: Argument 'dry_run' is set to True. Nothing will be deleted. Use '-v' to see detailed information. Aborting.
...
```