### PR TITLE
Add additional options support to base

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -394,6 +394,9 @@ class JamfUploaderBase(Processor):
         # additional headers for advanced requests
         if additional_headers:
             curl_cmd.extend(additional_headers)
+        # add additional flags specified
+        if self.env.get("curl_additional_opts"):
+            curl_cmd.extend(self.env.get("curl_additional_opts"))
 
         self.output(f"curl command: {' '.join(curl_cmd)}", verbose_level=3)
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -395,8 +395,8 @@ class JamfUploaderBase(Processor):
         if additional_headers:
             curl_cmd.extend(additional_headers)
         # add additional flags specified
-        if self.env.get("curl_additional_opts"):
-            curl_cmd.extend(self.env.get("curl_additional_opts"))
+        if self.env.get("custom_curl_opts"):
+            curl_cmd.extend(self.env.get("custom_curl_opts"))
 
         self.output(f"curl command: {' '.join(curl_cmd)}", verbose_level=3)
 


### PR DESCRIPTION
Add additional options field that can be specified to modify all curl requests in the event they are needed by certain environments (like an additional SSO login cookie)

Resolves #109 