### PR TITLE
Update JamfUploaderBase.py

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -598,7 +598,7 @@ class JamfUploaderBase(Processor):
                         replacement_key = escape(self.env.get(found_key))
                     else:
                         replacement_key = self.env.get(found_key)
-                    data = data.replace(f"%{found_key}%", replacement_key)
+                    data = data.replace(f"%{found_key}%", str(replacement_key))
                 else:
                     self.output(
                         f"WARNING: '{found_key}' has no replacement object!",
@@ -639,7 +639,7 @@ class JamfUploaderBase(Processor):
                         replacement_key = escape(cli_custom_keys[found_key])
                     else:
                         replacement_key = cli_custom_keys[found_key]
-                    data = data.replace(f"%{found_key}%", replacement_key)
+                    data = data.replace(f"%{found_key}%", str(replacement_key))
         return data
 
     def get_path_to_file(self, filename):

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -594,7 +594,7 @@ class JamfUploaderBase(Processor):
                         ),
                         verbose_level=2,
                     )
-                    if xml_escape:
+                    if xml_escape and type(self.env.get(found_key) is not int:
                         replacement_key = escape(self.env.get(found_key))
                     else:
                         replacement_key = self.env.get(found_key)
@@ -635,7 +635,7 @@ class JamfUploaderBase(Processor):
                         f"'{str(cli_custom_keys[found_key])}'",
                         verbose_level=2,
                     )
-                    if xml_escape:
+                    if xml_escape and type(self.env.get(found_key) is not int:
                         replacement_key = escape(cli_custom_keys[found_key])
                     else:
                         replacement_key = cli_custom_keys[found_key]

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -594,7 +594,7 @@ class JamfUploaderBase(Processor):
                         ),
                         verbose_level=2,
                     )
-                    if xml_escape and type(self.env.get(found_key) is not int:
+                    if xml_escape and type(self.env.get(found_key)) is not int:
                         replacement_key = escape(self.env.get(found_key))
                     else:
                         replacement_key = self.env.get(found_key)
@@ -635,7 +635,7 @@ class JamfUploaderBase(Processor):
                         f"'{str(cli_custom_keys[found_key])}'",
                         verbose_level=2,
                     )
-                    if xml_escape and type(self.env.get(found_key) is not int:
+                    if xml_escape and type(self.env.get(found_key)) is not int:
                         replacement_key = escape(cli_custom_keys[found_key])
                     else:
                         replacement_key = cli_custom_keys[found_key]


### PR DESCRIPTION
skip escaping ampersands in substituted keys if the key is an int

fixes #115 