### PR TITLE
Minor output improvement

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -637,10 +637,8 @@ class JamfUploaderBase(Processor):
             for found_key in found_keys:
                 if self.env.get(found_key) is not None:
                     self.output(
-                        (
-                            f"Replacing any instances of '{found_key}' with",
-                            f"'{str(self.env.get(found_key))}'",
-                        ),
+                        f"Replacing any instances of '{found_key}' with "
+                        f"'{str(self.env.get(found_key))}'",
                         verbose_level=2,
                     )
                     if xml_escape and type(self.env.get(found_key)) is not int:


### PR DESCRIPTION
This fixes the output to be printed as a `str` instead of as a `tuple`.

Before:
```
JamfPolicyUploader: ("Replacing any instances of 'policy_name' with", "'Escrow Buddy'")
JamfPolicyUploader: ("Replacing any instances of 'POLICY_FREQUENCY' with", "'Once per computer'")
JamfPolicyUploader: ("Replacing any instances of 'CATEGORY' with", "'Technical Support'")
JamfPolicyUploader: ("Replacing any instances of 'POLICY_TRIGGER_CHECKIN' with", "'True'")
```

After:
```
JamfPolicyUploader: Replacing any instances of 'policy_name' with 'Escrow Buddy'
JamfPolicyUploader: Replacing any instances of 'POLICY_FREQUENCY' with 'Once per computer'
JamfPolicyUploader: Replacing any instances of 'CATEGORY' with 'Technical Support'
JamfPolicyUploader: Replacing any instances of 'POLICY_TRIGGER_CHECKIN' with 'True'
JamfPolicyUploader: Replacing any instances of 'CUSTOM_TRIGGER' with 'Escrow_Buddy'
```