### PR TITLE
Convert variables to `str` before replacing values in templates

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -644,7 +644,7 @@ class JamfUploaderBase(Processor):
                         verbose_level=2,
                     )
                     if xml_escape and type(self.env.get(found_key)) is not int:
-                        replacement_key = escape(self.env.get(found_key))
+                        replacement_key = escape(str(self.env.get(found_key)))
                     else:
                         replacement_key = self.env.get(found_key)
                     data = data.replace(f"%{found_key}%", str(replacement_key))


### PR DESCRIPTION
When a substitutable key with non-`str` (e.g. boolean-like) value is ran through `xml.sax.saxutils.escape`, it's being converted to a `bool` and then attempts to run `str`'s `.replace` method on it, causing it to fail.

Sample error:

```
JamfPolicyUploader: Replacing any instances of 'POLICY_TRIGGER_CHECKIN' with 'true'
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 626, in process
    self.main()
  File "/Library/<username>/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/JamfUploaderProcessors/JamfPolicyUploader.py", line 341, in main
    template_xml = self.prepare_policy_template(
  File "/Library/<username>/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/JamfUploaderProcessors/JamfPolicyUploader.py", line 123, in prepare_policy_template
    template_contents = self.substitute_assignable_keys(
  File "/Library/<username>/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py", line 634, in substitute_assignable_keys
    replacement_key = escape(self.env.get(found_key))
  File "/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/xml/sax/saxutils.py", line 27, in escape
    data = data.replace("&", "&amp;")
AttributeError: 'bool' object has no attribute 'replace'
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
'bool' object has no attribute 'replace'
Failed.
```

AutoPkg is currently written to convert all the `YAML` values to their Python `type`s, which helps lead to this issue.  I have submitted a proposal to prevent this in AutoPkg itself as well in [#911](https://github.com/autopkg/autopkg/pull/911), but not sure if this is something that will be/or should be considered as it makes an assumption that all variable types _are_ and _should be_ of the `str` type.

This is some-what the recipe writers fault, which I acknowledge as well.