### PR TITLE
Add ea_description argument to JamfExtensionAttributeUploader

### DIFF
--- a/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
+++ b/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
@@ -93,6 +93,11 @@ class JamfExtensionAttributeUploader(JamfExtensionAttributeUploaderBase):
             "description": "Data type for the EA. One of String, Integer or Date.",
             "default": "String",
         },
+        "ea_description": {
+            "required": False,
+            "description": "Description for the EA.",
+            "default": "String",
+        },
         "sleep": {
             "required": False,
             "description": "Pause after running this processor for specified seconds.",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
@@ -42,6 +42,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         jamf_url,
         ea_name,
         ea_data_type,
+        ea_description,
         ea_inventory_display,
         script_path,
         token,
@@ -66,7 +67,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
             "<computer_extension_attribute>"
             + "<name>{}</name>".format(ea_name)
             + "<enabled>true</enabled>"
-            + "<description/>"
+            + "<description>{}</description>".format(ea_description)
             + "<data_type>{}</data_type>".format(ea_data_type)
             + "<input_type>"
             + "  <type>script</type>"
@@ -134,6 +135,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         self.ea_name = self.env.get("ea_name")
         self.replace = self.env.get("replace_ea")
         self.ea_data_type = self.env.get("ea_data_type")
+        self.ea_description = self.env.get("ea_description")
         self.ea_inventory_display = self.env.get("ea_inventory_display")
         self.sleep = self.env.get("sleep")
         # handle setting replace in overrides
@@ -201,6 +203,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
             self.jamf_url,
             self.ea_name,
             self.ea_data_type,
+            self.ea_description,
             self.ea_inventory_display,
             self.ea_script_path,
             token=token,


### PR DESCRIPTION
Add `ea_description` argument to the JamfExtensionAttributeUploader processor so extension attribute descriptions in Jamf can be maintained via recipe.