### PR TITLE
Add skip_script_key_substitution to JamfExtensionAttributeUploader

### DIFF
--- a/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
+++ b/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
@@ -93,6 +93,11 @@ class JamfExtensionAttributeUploader(JamfExtensionAttributeUploaderBase):
             "description": "Data type for the EA. One of String, Integer or Date.",
             "default": "String",
         },
+        "skip_script_key_substitution": {
+            "required": False,
+            "description": "Skip key substitution in processing the script",
+            "default": False,
+        },
         "sleep": {
             "required": False,
             "description": "Pause after running this processor for specified seconds.",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
@@ -44,6 +44,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         ea_data_type,
         ea_inventory_display,
         script_path,
+        skip_script_key_substitution,
         token,
         obj_id=None,
     ):
@@ -55,8 +56,9 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         else:
             raise ProcessorError("Script does not exist!")
 
-        # substitute user-assignable keys
-        script_contents = self.substitute_assignable_keys(script_contents)
+        if not skip_script_key_substitution:
+            # substitute user-assignable keys
+            script_contents = self.substitute_assignable_keys(script_contents)
 
         # XML-escape the script
         script_contents_escaped = escape(script_contents)
@@ -132,6 +134,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         self.client_secret = self.env.get("CLIENT_SECRET")
         self.ea_script_path = self.env.get("ea_script_path")
         self.ea_name = self.env.get("ea_name")
+        self.skip_script_key_substitution = self.env.get("skip_script_key_substitution")
         self.replace = self.env.get("replace_ea")
         self.ea_data_type = self.env.get("ea_data_type")
         self.ea_inventory_display = self.env.get("ea_inventory_display")
@@ -139,6 +142,11 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         # handle setting replace in overrides
         if not self.replace or self.replace == "False":
             self.replace = False
+        if (
+            not self.skip_script_key_substitution
+            or self.skip_script_key_substitution == "False"
+        ):
+            self.skip_script_key_substitution = False
 
         # clear any pre-existing summary result
         if "jamfextensionattributeuploader_summary_result" in self.env:
@@ -203,6 +211,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
             self.ea_data_type,
             self.ea_inventory_display,
             self.ea_script_path,
+            self.skip_script_key_substitution,
             token=token,
             obj_id=obj_id,
         )

--- a/JamfUploaderProcessors/READMEs/JamfExtensionAttributeUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfExtensionAttributeUploader.md
@@ -39,6 +39,10 @@ A processor for AutoPkg that will upload an Extension Attribute item to a Jamf C
   - **required:** False
   - **description:** Data type for the EA. One of String, Integer or Date.
   - **default:** "String"
+- **skip_script_key_substitution**:
+  - **required**: False
+  - **description**: Skip substitution of keys marked between `%` signs in the script.
+  - **default**: False
 - **sleep:**
   - **required:** False
   - **description:** Pause after running this processor for specified seconds.


### PR DESCRIPTION
This PR replicates the `skip_script_key_substitution` option of `JamfScriptUploader` into `JamfExtensionAttributeUploader`. It should resolve issue #127.