### PR TITLE
Update JamfPackageUploaderBase.py

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
@@ -563,7 +563,7 @@ class JamfPackageUploaderBase(JamfUploaderBase):
         self.jcds_mode = self.env.get("jcds_mode")
         self.jcds2_mode = self.env.get("jcds2_mode")
         self.aws_cdp_mode = self.env.get("aws_cdp_mode")
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip('/')
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")


### PR DESCRIPTION
Tweak to strip any trailing slashes off JSS_URL.  I know, it says it right here in the docs (https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors) not to have it there, but it still took me a day to realise what was screwing up the processor!

I realise this will require the same update to all the JamfUploader processors - I'm happy to do pull requests for all of them if you're ok to use this tweak.