### PR TITLE
Update JamfAccountUploaderBase.py

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
@@ -140,7 +140,7 @@ class JamfAccountUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload the account"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip('/')
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")


### PR DESCRIPTION
Tweak to strip any trailing slashes off JSS_URL, as already tweaked in https://github.com/grahampugh/jamf-upload/pull/134.