### PR TITLE
Update JamfPackageCleanerBase.py to handle trailing slashes on JSS_URL

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
@@ -93,7 +93,7 @@ class JamfPackageCleanerBase(JamfUploaderBase):
         """Clean up old packages in Jamf Pro"""
 
         # Get the necessary environment variables
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip('/')
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")


### PR DESCRIPTION
Tweak to strip any trailing slashes off JSS_URL, as already tweaked in https://github.com/grahampugh/jamf-upload/pull