### PR TITLE
Update JamfPatchCheckerBase.py to handle trailing slashes on JSS_URL

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPatchCheckerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPatchCheckerBase.py
@@ -111,7 +111,7 @@ class JamfPatchCheckerBase(JamfUploaderBase):
 
     def execute(self):
         """Do the main thing here"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip('/')
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")


### PR DESCRIPTION
Tweak to strip any trailing slashes off JSS_URL, as already tweaked in https://github.com/grahampugh/jamf-upload/pull/134