### PR TITLE
Update JamfPatchUploaderBase.py to handle trailing slashes on JSS_URL

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
@@ -241,7 +241,7 @@ class JamfPatchUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a patch policy"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip('/')
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")


### PR DESCRIPTION
Tweak to strip any trailing slashes off JSS_URL, as already tweaked in https://github.com/grahampugh/jamf-upload/pull/134