### PR TITLE
Update JamfSoftwareRestrictionUploaderBase.py to handle trailing slashes on JSS_URL

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
@@ -115,7 +115,7 @@ class JamfSoftwareRestrictionUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a software restriction"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip('/')
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")


### PR DESCRIPTION
Tweak to strip any trailing slashes off JSS_URL, as already tweaked in https://github.com/grahampugh/jamf-upload/pull/134