### PR TITLE
Update JamfClassicAPIObjectUploaderBase.py to handle trailing slashes on JSS_URL

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfClassicAPIObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfClassicAPIObjectUploaderBase.py
@@ -104,7 +104,7 @@ class JamfClassicAPIObjectUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload an API object"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip('/')
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")


### PR DESCRIPTION
Tweak to strip any trailing slashes off JSS_URL, as already tweaked in https://github.com/grahampugh/jamf-upload/pull/134