### PR TITLE
Add oauth token handling to package deletion step

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
@@ -260,9 +260,14 @@ class JamfPackageCleanerBase(JamfUploaderBase):
 
         for package in packages_to_delete:
             # package deletion could take time, so we check the token before each deletion
-            token = self.handle_api_auth(
-                self.jamf_url, self.jamf_user, self.jamf_password
-            )
+            if self.jamf_url and self.client_id and self.client_secret:
+                token = self.handle_oauth(self.jamf_url, self.client_id, self.client_secret)
+            elif self.jamf_url and self.jamf_user and self.jamf_password:
+                token = self.handle_api_auth(
+                    self.jamf_url, self.jamf_user, self.jamf_password
+                )
+            else:
+                raise ProcessorError("ERROR: Credentials not supplied")
             self.delete_package(
                 jamf_url=self.jamf_url, obj_id=package["id"], token=token
             )


### PR DESCRIPTION
Fixes #135 

Currently, the loop handling deletion of packages only attempts to retrieve an authentication token using basic authentication. If preferences have been set for `client_id` and `client_secret`, oauth should instead be used to get a token. This is handled using the added `if/else` block, which takes different actions based on configured preferences. The added block is identical to that found higher up on line 194 in this script.