### PR TITLE
Update webhook text for package uploaded but no policy uploaded

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderTeamsNotifier.py
+++ b/JamfUploaderProcessors/JamfUploaderTeamsNotifier.py
@@ -251,7 +251,7 @@ class JamfUploaderTeamsNotifier(JamfUploaderBase):
             webhook_text["attachments"][0]["content"]["body"].append(
                 {
                     "type": "TextBlock",
-                    "text": "No new package uploaded.",
+                    "text": "No new policy uploaded.",
                     "wrap": True,
                     "separator": True
                 }


### PR DESCRIPTION
We have some packages that we upload for availability but do not create policies to auto update.  

We receive messages in teams that end with "No new package uploaded" when that happens, but not if a policy is also uploaded.  Seems like maybe the text just needed to be changed here: (referencing https://github.com/grahampugh/jamf-upload/issues/173)