### PR TITLE
Added fallback behaviour for pkg category in Teams and Slack webhook delivery (fixes #111)

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderSlacker.py
+++ b/JamfUploaderProcessors/JamfUploaderSlacker.py
@@ -125,6 +125,9 @@ class JamfUploaderSlacker(JamfUploaderBase):
         slack_channel = self.env.get("slack_channel") or ""
         slack_icon_emoji = self.env.get("slack_icon_emoji") or ""
 
+        if (not category and jamfpackageuploader_summary_result):
+            category = jamfpackageuploader_summary_result["data"]["category"]
+
         selfservice_policy_name = name
         self.output(f"JSS address: {jss_url}")
         self.output(f"Title: {selfservice_policy_name}")

--- a/JamfUploaderProcessors/JamfUploaderTeamsNotifier.py
+++ b/JamfUploaderProcessors/JamfUploaderTeamsNotifier.py
@@ -111,6 +111,9 @@ class JamfUploaderTeamsNotifier(JamfUploaderBase):
             "jamfpolicyuploader_summary_result"
         )
 
+        if (not category and jamfpackageuploader_summary_result):
+            category = jamfpackageuploader_summary_result["data"]["category"]
+
         teams_webhook_url = self.env.get("teams_webhook_url")
         teams_username = self.env.get("teams_username")
         teams_icon_url = (


### PR DESCRIPTION
In the Teams postprocessor, the package category is only passed into the embed via the `APP_CATEGORY` variable, which seems to need to be explicitly set, and doesn't appear to be the output of any of the other JamfUploader processors.

This MR adds fallback behaviour where, **if** `APP_CATEGORY` is unset **and** a `jamfpackageuploader_summary_result` is present, an attempt is made to extract the package category from the `jamfpackageuploader_summary_result`. I have tested the JSON that the Teams postprocessor sends as a result of this change, and it now includes a category when `jamfpackageuploader_summary_result` contains one.

I also went over the Slack postprocessor (as I originally based the Teams one off of it), and at least at a glance it looks like it suffers from the same issue. I included the same fix in this postprocessor as well.