### PR TITLE
Ensure trailing slash is stripped from Jamf URL input on all processors

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
@@ -140,7 +140,7 @@ class JamfAccountUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload the account"""
-        jamf_url = self.env.get("JSS_URL")
+        jamf_url = self.env.get("JSS_URL").rstrip("/")
         jamf_user = self.env.get("API_USERNAME")
         jamf_password = self.env.get("API_PASSWORD")
         client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfCategoryUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfCategoryUploaderBase.py
@@ -82,7 +82,7 @@ class JamfCategoryUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a category"""
-        jamf_url = self.env.get("JSS_URL")
+        jamf_url = self.env.get("JSS_URL").rstrip("/")
         jamf_user = self.env.get("API_USERNAME")
         jamf_password = self.env.get("API_PASSWORD")
         client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfClassicAPIObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfClassicAPIObjectUploaderBase.py
@@ -106,7 +106,7 @@ class JamfClassicAPIObjectUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload an API object"""
-        jamf_url = self.env.get("JSS_URL")
+        jamf_url = self.env.get("JSS_URL").rstrip("/")
         jamf_user = self.env.get("API_USERNAME")
         jamf_password = self.env.get("API_PASSWORD")
         client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupDeleterBase.py
@@ -72,7 +72,7 @@ class JamfComputerGroupDeleterBase(JamfUploaderBase):
 
     def execute(self):
         """Delete a computer group"""
-        jamf_url = self.env.get("JSS_URL")
+        jamf_url = self.env.get("JSS_URL").rstrip("/")
         jamf_user = self.env.get("API_USERNAME")
         jamf_password = self.env.get("API_PASSWORD")
         client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupUploaderBase.py
@@ -121,7 +121,7 @@ class JamfComputerGroupUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a computer group"""
-        jamf_url = self.env.get("JSS_URL")
+        jamf_url = self.env.get("JSS_URL").rstrip("/")
         jamf_user = self.env.get("API_USERNAME")
         jamf_password = self.env.get("API_PASSWORD")
         client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
@@ -288,7 +288,7 @@ class JamfComputerProfileUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a configuration profile"""
-        jamf_url = self.env.get("JSS_URL")
+        jamf_url = self.env.get("JSS_URL").rstrip("/")
         jamf_user = self.env.get("API_USERNAME")
         jamf_password = self.env.get("API_PASSWORD")
         client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfDockItemUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfDockItemUploaderBase.py
@@ -100,7 +100,7 @@ class JamfDockItemUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a dock item"""
-        jamf_url = self.env.get("JSS_URL")
+        jamf_url = self.env.get("JSS_URL").rstrip("/")
         jamf_user = self.env.get("API_USERNAME")
         jamf_password = self.env.get("API_PASSWORD")
         client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
@@ -129,7 +129,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload an extension attribute"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip("/")
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfIconUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfIconUploaderBase.py
@@ -106,7 +106,7 @@ class JamfIconUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload an icone"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip("/")
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
@@ -119,7 +119,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a mac app"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip("/")
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceGroupUploaderBase.py
@@ -102,7 +102,7 @@ class JamfMobileDeviceGroupUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a mobile device group"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip("/")
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
@@ -202,7 +202,7 @@ class JamfMobileDeviceProfileUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a mobile device configuration profile"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip("/")
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
@@ -241,7 +241,7 @@ class JamfPatchUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a patch policy"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip("/")
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyDeleterBase.py
@@ -65,7 +65,7 @@ class JamfPolicyDeleterBase(JamfUploaderBase):
 
     def execute(self):
         """Delete a policy"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip("/")
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyLogFlusherBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyLogFlusherBase.py
@@ -74,7 +74,7 @@ class JamfPolicyLogFlusherBase(JamfUploaderBase):
 
     def execute(self):
         """Flush a policy log"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip("/")
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
@@ -202,7 +202,7 @@ class JamfPolicyUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a policy"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip("/")
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
@@ -142,7 +142,7 @@ class JamfScriptUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a script"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip("/")
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
@@ -117,7 +117,7 @@ class JamfSoftwareRestrictionUploaderBase(JamfUploaderBase):
 
     def execute(self):
         """Upload a software restriction"""
-        self.jamf_url = self.env.get("JSS_URL")
+        self.jamf_url = self.env.get("JSS_URL").rstrip("/")
         self.jamf_user = self.env.get("API_USERNAME")
         self.jamf_password = self.env.get("API_PASSWORD")
         self.client_id = self.env.get("CLIENT_ID")


### PR DESCRIPTION
Spotted this from https://macadmins.slack.com/archives/C01AVR04ES1/p1736206635304099

Hopefully something in Python I do know how to do without breaking everything!

I haven't been able to test this as not on my work computer until tomorrow.

🤞🏼 