### PR TITLE
Use Jamf Pro API for EA Upload

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
@@ -63,25 +63,23 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
             # substitute user-assignable keys
             script_contents = self.substitute_assignable_keys(script_contents)
 
-        # XML-escape the script
-        script_contents_escaped = escape(script_contents)
+        # format inventoryDisplayType & dataType correctly
+        ea_inventory_display = ea_inventory_display.replace(" ", "_").upper()
+        ea_data_type = ea_data_type.upper()
+
+        self.output(type(ea_inventory_display), verbose_level=1)
 
         # build the object
-        ea_data = (
-            "<computer_extension_attribute>"
-            + "<name>{}</name>".format(ea_name)
-            + "<enabled>true</enabled>"
-            + "<description>{}</description>".format(ea_description)
-            + "<data_type>{}</data_type>".format(ea_data_type)
-            + "<input_type>"
-            + "  <type>script</type>"
-            + "  <platform>Mac</platform>"
-            + "  <script>{}</script>".format(script_contents_escaped)
-            + "</input_type>"
-            + "<inventory_display>{}</inventory_display>".format(ea_inventory_display)
-            + "<recon_display>Extension Attributes</recon_display>"
-            + "</computer_extension_attribute>"
-        )
+        ea_data = {
+            "name": ea_name,
+            "enabled": True,
+            "description": ea_description,
+            "dataType": ea_data_type,
+            "inventoryDisplayType": ea_inventory_display,
+            "inputType": "script",
+            "scriptContents": script_contents,
+        }
+
         self.output(
             "Extension Attribute data:",
             verbose_level=2,
@@ -92,12 +90,14 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         )
 
         self.output("Uploading Extension Attribute...")
-        # write the template to temp file
-        template_xml = self.write_temp_file(ea_data)
+        ea_json = self.write_json_file(ea_data)
 
         # if we find an object ID we put, if not, we post
         object_type = "extension_attribute"
-        url = "{}/{}/id/{}".format(jamf_url, self.api_endpoints(object_type), obj_id)
+        if obj_id:
+            url = "{}/{}/{}".format(jamf_url, self.api_endpoints(object_type), obj_id)
+        else:
+            url = "{}/{}".format(jamf_url, self.api_endpoints(object_type))
 
         count = 0
         while True:
@@ -107,13 +107,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
                 verbose_level=2,
             )
             request = "PUT" if obj_id else "POST"
-            r = self.curl(
-                request=request,
-                url=url,
-                token=token,
-                data=template_xml,
-            )
-
+            r = self.curl(request=request, url=url, token=token, data=ea_json)
             # check HTTP response
             if self.status_check(r, "Extension Attribute", ea_name, request) == "break":
                 break
@@ -181,10 +175,10 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         # check for existing - requires obj_name
         obj_type = "extension_attribute"
         obj_name = self.ea_name
-        obj_id = self.get_api_obj_id_from_name(
+        obj_id = self.get_uapi_obj_id_from_name(
             self.jamf_url,
-            obj_name,
             obj_type,
+            obj_name,
             token,
         )
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -546,7 +546,7 @@ class JamfUploaderBase(Processor):
         else:
             action = "unknown"
 
-        if r.status_code == 200 or r.status_code == 201:
+        if r.status_code == 200 or r.status_code == 201 or r.status_code == 202:
             if endpoint_type == "jcds":
                 self.output("JCDS2 credentials successfully received", verbose_level=2)
             else:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -49,7 +49,7 @@ class JamfUploaderBase(Processor):
         api_endpoints = {
             "account": "JSSResource/accounts",
             "category": "uapi/v1/categories",
-            "extension_attribute": "JSSResource/computerextensionattributes",
+            "extension_attribute": "api/v1/computer-extension-attributes",
             "computer_group": "JSSResource/computergroups",
             "configuration_profile": "JSSResource/mobiledeviceconfigurationprofiles",
             "dock_item": "JSSResource/dockitems",


### PR DESCRIPTION
**Background**
In the Jamf Classic API, the `inventory_display` field is with only 6 valid values, which are case sensitive.  As the API documentation does not mention this, the case sensitivity may be specific to newer versions of Jamf Pro.  In the Jamf Pro UI, the dropdown for selecting an inventory display category shows the values with only the first character capitalized.  When showing in an inventory record, they are shown using uppercase for all words except "and".

**Problem**
If the case of an `inventory_display` is incorrect, the value is still accepted by the Classic API.  For example, one can submit `Operating system` instead of `Operating System` and it will be accepted and stored incorrectly by the API.

The resulting EA causes a 500 error to be thrown when attempting to view any computer record in the Jamf Pro API, which in turn causes issues with displaying the "General" section of the Inventory tab when viewing the record in the Jamf Pro UI.

**Solution**
This could be solved altering the case of any incorrect `ea_inventory_display` value in `JamfExtensionAttributeUploaderBase.py`, however after seeing that the script uploader used the new API, it seemed like a good reason to have the EA uploader use the new API as well, which I believe will do a better job at rejecting invalid `inventory_display` values.

The change is fairly basic, and was modeled after the code in `JamfScriptUploaderBase.py`.

One additional change was made to allow for the 202 response codes, as the [PUT method ](https://developer.jamf.com/jamf-pro/reference/put_v1-computer-extension-attributes-id)of the `computer-extension-attributes` API endpoint uses that code.