### PR TITLE
Update JamfExtensionAttributeUploaderBase.py

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
@@ -68,7 +68,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         ea_inventory_display = ea_inventory_display.replace(" ", "_").upper()
         ea_data_type = ea_data_type.upper()
 
-        self.output("Data type: " + type(ea_inventory_display), verbose_level=3)
+        self.output("Data type: " + str(ea_inventory_display), verbose_level=3)
 
         # build the object
         ea_data = {


### PR DESCRIPTION
Fixes this error:
```
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 626, in process
    self.main()
  File "/Users/Shared/GitHub/jamf-upload/JamfUploaderProcessors/JamfExtensionAttributeUploader.py", line 122, in main
    self.execute()
  File "/Users/Shared/GitHub/jamf-upload/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py", line 199, in execute
    self.upload_ea(
  File "/Users/Shared/GitHub/jamf-upload/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py", line 71, in upload_ea
    self.output("Data type: " + type(ea_inventory_display), verbose_level=3)
TypeError: can only concatenate str (not "type") to str
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
can only concatenate str (not "type") to str
```