### PR TITLE
Update JamfClassicAPIObjectUploaderBase.py

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfClassicAPIObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfClassicAPIObjectUploaderBase.py
@@ -196,9 +196,10 @@ class JamfClassicAPIObjectUploaderBase(JamfUploaderBase):
         if object_updated:
             self.env["jamfclassicapiobjectuploader_summary_result"] = {
                 "summary_text": "The following objects were updated in Jamf Pro:",
-                "report_fields": [object_type, "template"],
+                "report_fields": ["object_name", "object_type", "template"],
                 "data": {
-                    object_type: object_name,
+                    "object_type": object_type,
+                    "object_name": object_name,
                     "template": object_template,
                 },
             }


### PR DESCRIPTION
Fixes the following error if you use more than one instance of this processor in a recipe and create different object types:

```
The following objects were updated in Jamf Pro:
Traceback (most recent call last):
  File "/usr/local/bin/autopkg", line 2786, in <module>
    sys.exit(main(sys.argv))
  File "/usr/local/bin/autopkg", line 2782, in main
    return subcommands[verb]["function"](argv)
  File "/usr/local/bin/autopkg", line 2385, in run_recipes
    this_row.append(row[field])
KeyError: 'mobile_device_extension_attribute'
```

Summary output is:

```
The following objects were updated in Jamf Pro:
    Object Name                              Object Type                        Template                                                                                                                                           
    -----------                              -----------                        --------                                                                                                                                           
    Role                                     mobile_device_extension_attribute  /Users/neil.martin/Library/AutoPkg/Cache/JamfMSP-private-recipes.jamf.DJmobi-MobileDeviceRole/nmartin-mobile_device_extension_attributes-Role.xml  
    Public - All Shared Devices - Test Role  advanced_mobile_device_search      /Users/Shared/GitHub/msp-internal-recipes/DJmobi-MobileDeviceRole/_Template-DJmobi-AdvancedMobileDeviceSearch-ROLE.xml                             
```