### PR TITLE
Allow parse of a list of objects

### DIFF
--- a/JamfUploaderProcessors/JamfObjectReader.py
+++ b/JamfUploaderProcessors/JamfObjectReader.py
@@ -39,40 +39,49 @@ __all__ = ["JamfObjectReader"]
 class JamfObjectReader(JamfObjectReaderBase):
     """Processor to read an API object"""
 
-    description = (
-        "A processor for AutoPkg that will read an API object template "
-        "on a Jamf Pro server."
-        "'Jamf Pro privileges are required by the API_USERNAME user for whatever the endpoint is."
-    )
+    description = """
+        A processor for AutoPkg that will read an API object template on a Jamf Pro server.
+        Jamf Pro privileges are required by the API_USERNAME user for whatever the endpoint is.
+    """
 
     input_variables = {
         "JSS_URL": {
             "required": True,
-            "description": "URL to a Jamf Pro server that the API user has write access "
-            "to, optionally set as a key in the com.github.autopkg "
-            "preference file.",
+            "description": (
+                "URL to a Jamf Pro server that the API user has write access "
+                "to, optionally set as a key in the com.github.autopkg "
+                "preference file."
+            ),
         },
         "API_USERNAME": {
             "required": False,
-            "description": "Username of account with appropriate access to "
-            "jss, optionally set as a key in the com.github.autopkg "
-            "preference file.",
+            "description": (
+                "Username of account with appropriate access to "
+                "jss, optionally set as a key in the com.github.autopkg "
+                "preference file."
+            ),
         },
         "API_PASSWORD": {
             "required": False,
-            "description": "Password of api user, optionally set as a key in "
-            "the com.github.autopkg preference file.",
+            "description": (
+                "Password of api user, optionally set as a key in "
+                "the com.github.autopkg preference file."
+            ),
         },
         "CLIENT_ID": {
             "required": False,
-            "description": "Client ID with access to "
-            "jss, optionally set as a key in the com.github.autopkg "
-            "preference file.",
+            "description": (
+                "Client ID with access to "
+                "jss, optionally set as a key in the com.github.autopkg "
+                "preference file."
+            ),
         },
         "CLIENT_SECRET": {
             "required": False,
-            "description": "Secret associated with the Client ID, optionally set as a key in "
-            "the com.github.autopkg preference file.",
+            "description": (
+                "Secret associated with the Client ID, optionally set as a key in "
+                "the com.github.autopkg preference file."
+            ),
         },
         "object_name": {
             "required": False,
@@ -88,6 +97,13 @@ class JamfObjectReader(JamfObjectReaderBase):
             "required": False,
             "description": "Path (folder) to dump the xml or json file",
             "default": "",
+        },
+        "elements_to_remove": {
+            "required": False,
+            "description": (
+                "A list of XML or JSON elements that should be removed from the downloaded XML. "
+                "Note that id and self_service_icon are removed automatically."
+            ),
         },
         "all_objects": {
             "required": False,

--- a/JamfUploaderProcessors/JamfObjectUploader.py
+++ b/JamfUploaderProcessors/JamfObjectUploader.py
@@ -86,6 +86,14 @@ class JamfObjectUploader(JamfObjectUploaderBase):
             "description": "Type of the object. This is the name of the key in the XML template",
             "default": "",
         },
+        "elements_to_remove": {
+            "required": False,
+            "description": (
+                "A list of XML or JSON elements that should be removed from the downloaded XML. "
+                "Note that id and self_service_icon are removed automatically."
+            ),
+            "default": None,
+        },
         "replace_object": {
             "required": False,
             "description": "Overwrite an existing object if True.",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAPIRoleUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAPIRoleUploaderBase.py
@@ -117,7 +117,9 @@ class JamfAPIRoleUploaderBase(JamfUploaderBase):
 
         # we need to substitute the values in the object name and template now to
         # account for version strings in the name
-        object_name, template_file = self.prepare_template(object_name, object_template)
+        object_name, template_file = self.prepare_template(
+            object_name, object_type, object_template
+        )
 
         # now start the process of uploading the object
         self.output(f"Checking for existing '{object_name}' on {jamf_url}")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfClassicAPIObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfClassicAPIObjectUploaderBase.py
@@ -118,7 +118,7 @@ class JamfClassicAPIObjectUploaderBase(JamfUploaderBase):
         # we need to substitute the values in the object name and template now to
         # account for version strings in the name
         object_name, template_file = self.prepare_template(
-            object_name, object_template, xml_escape=True
+            object_name, object_type, object_template, xml_escape=True
         )
 
         # now start the process of uploading the object

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -52,6 +52,9 @@ class JamfObjectReaderBase(JamfUploaderBase):
         all_objects = self.env.get("all_objects")
         object_type = self.env.get("object_type")
         output_path = self.env.get("output_path")
+        elements_to_remove = self.env.get("elements_to_remove")
+        if isinstance(elements_to_remove, str):
+            elements_to_remove = [elements_to_remove]
 
         # handle setting true/false variables in overrides
         if not all_objects or all_objects == "False":
@@ -122,7 +125,9 @@ class JamfObjectReaderBase(JamfUploaderBase):
             )
 
             # parse the object
-            parsed_object = self.parse_downloaded_api_object(raw_object, object_type)
+            parsed_object = self.parse_downloaded_api_object(
+                raw_object, object_type, elements_to_remove
+            )
 
             # for certain types we also want to extract the payload
             payload = ""

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -22,8 +22,6 @@ import os.path
 import sys
 import xml.etree.ElementTree as ET
 
-from xml.sax.saxutils import unescape
-
 from autopkglib import (  # pylint: disable=import-error
     ProcessorError,
 )
@@ -176,7 +174,10 @@ class JamfObjectReaderBase(JamfUploaderBase):
                         self.output(f"Wrote parsed object to {file_path}")
                         # also output the payload if appropriate
                         if payload:
-                            payload_output_filename = f"{subdomain}-{self.object_list_types(object_type)}-{n}.{payload_filetype}"
+                            payload_output_filename = (
+                                f"{subdomain}-{self.object_list_types(object_type)}-{n}"
+                                f".{payload_filetype}"
+                            )
                             payload_file_path = os.path.join(
                                 output_path, payload_output_filename
                             )

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
@@ -144,14 +144,19 @@ class JamfObjectUploaderBase(JamfUploaderBase):
         else:
             raise ProcessorError("ERROR: Credentials not supplied")
 
+        # declare name key
+        name_key = "name"
+        if (
+            object_type == "computer_prestage"
+            or object_type == "mobile_device_prestage"
+        ):
+            name_key = "displayName"
+
         # Check for existing item
         self.output(f"Checking for existing '{object_name}' on {jamf_url}")
 
         obj_id = self.get_api_obj_id_from_name(
-            jamf_url,
-            object_name,
-            object_type,
-            token=token,
+            jamf_url, object_name, object_type, token=token, filter_name=name_key
         )
 
         if obj_id:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
@@ -60,7 +60,10 @@ class JamfObjectUploaderBase(JamfUploaderBase):
             # do XML stuff
             url = f"{jamf_url}/{self.api_endpoints(object_type)}/id/{obj_id}"
         else:
-            url = f"{jamf_url}/{self.api_endpoints(object_type)}/{obj_id}"
+            if obj_id:
+                url = f"{jamf_url}/{self.api_endpoints(object_type)}/{obj_id}"
+            else:
+                url = f"{jamf_url}/{self.api_endpoints(object_type)}"
 
         count = 0
         while True:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
@@ -99,6 +99,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
         object_type = self.env.get("object_type")
         object_template = self.env.get("object_template")
         replace_object = self.env.get("replace_object")
+        elements_to_remove = self.env.get("elements_to_remove")
         sleep_time = self.env.get("sleep")
         # handle setting replace in overrides
         if not replace_object or replace_object == "False":
@@ -126,7 +127,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
         else:
             xml_escape = False
         object_name, template_file = self.prepare_template(
-            object_name, object_template, xml_escape
+            object_name, object_type, object_template, xml_escape, elements_to_remove
         )
 
         # now start the process of uploading the object

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
@@ -57,7 +57,7 @@ class JamfSoftwareRestrictionUploaderBase(JamfUploaderBase):
     ):
         """Update Software Restriction metadata."""
 
-        # substitute user-assignable keys
+        # # substitute user-assignable keys
         replaceable_keys = {
             "restriction_name": restriction_name,
             "process_name": process_name,
@@ -72,6 +72,11 @@ class JamfSoftwareRestrictionUploaderBase(JamfUploaderBase):
         # substitute user-assignable keys (escaping for XML)
         template_contents = self.substitute_limited_assignable_keys(
             template_contents, replaceable_keys, xml_escape=True
+        )
+
+        # substitute env keys (escaping for XML)
+        template_contents = self.substitute_assignable_keys(
+            template_contents, xml_escape=True
         )
 
         self.output("Software Restriction to be uploaded:", verbose_level=2)

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -128,28 +128,6 @@ class JamfUploaderBase(Processor):
         }
         return object_list_types[object_type]
 
-    def prepare_template(self, object_name, object_template, xml_escape=False):
-        """prepare the object contents"""
-        # import template from file and replace any keys in the template
-        if os.path.exists(object_template):
-            with open(object_template, "r", encoding="utf-8") as file:
-                template_contents = file.read()
-        else:
-            raise ProcessorError("Template does not exist!")
-
-        # substitute user-assignable keys
-        object_name = self.substitute_assignable_keys(object_name)
-        template_contents = self.substitute_assignable_keys(
-            template_contents, xml_escape
-        )
-
-        self.output("object data:", verbose_level=2)
-        self.output(template_contents, verbose_level=2)
-
-        # write the template to temp file
-        template_file = self.write_temp_file(template_contents)
-        return object_name, template_file
-
     def write_json_file(self, data):
         """dump some json to a temporary file"""
         tf = self.init_temp_file(suffix=".json")
@@ -1013,7 +991,9 @@ class JamfUploaderBase(Processor):
                 # parent.remove(elem)
                 elem.text = replacement_value
 
-    def parse_downloaded_api_object(self, existing_object, object_type):
+    def parse_downloaded_api_object(
+        self, existing_object, object_type, elements_to_remove=None
+    ):
         """Removes or replaces instance-specific items such as ID and computer objects"""
         # first determine if this object is using Classic API or Jamf Pro
         if "JSSResource" in self.api_endpoints(object_type):
@@ -1025,16 +1005,13 @@ class JamfUploaderBase(Processor):
 
                 # remove any id tags
                 self.remove_elements_from_xml(object_xml, "id")
-                # remove any computer objects
-                self.remove_elements_from_xml(object_xml, "computers")
-                # remove any mobile device objects
-                self.remove_elements_from_xml(object_xml, "mobile_devices")
-                # remove any user-based objects
-                self.remove_elements_from_xml(object_xml, "users")
-                self.remove_elements_from_xml(object_xml, "user_groups")
-                self.remove_elements_from_xml(object_xml, "limit_to_users")
                 # remove any self service icons
                 self.remove_elements_from_xml(object_xml, "self_service_icon")
+                # optional array of other elements to remove
+                for elem in elements_to_remove:
+                    self.output(f"Deleting element {elem}...", verbose_level=2)
+                    self.remove_elements_from_xml(object_xml, elem)
+
                 # for profiles ensure that they are redeployed to all
                 self.substitute_elements_in_xml(object_xml, "redeploy_on_update", "All")
 
@@ -1058,6 +1035,40 @@ class JamfUploaderBase(Processor):
                     if "id" in elem:
                         elem.pop("id")
             return json.dumps(existing_object, indent=4)
+
+    def prepare_template(
+        self,
+        object_name,
+        object_type,
+        object_template,
+        xml_escape=False,
+        elements_to_remove=None,
+    ):
+        """prepare the object contents"""
+        # import template from file and replace any keys in the template
+        if os.path.exists(object_template):
+            with open(object_template, "r", encoding="utf-8") as file:
+                template_contents = file.read()
+        else:
+            raise ProcessorError("Template does not exist!")
+
+        # parse the template
+        template_contents = self.parse_downloaded_api_object(
+            template_contents, object_type, elements_to_remove
+        )
+
+        # substitute user-assignable keys
+        object_name = self.substitute_assignable_keys(object_name)
+        template_contents = self.substitute_assignable_keys(
+            template_contents, xml_escape
+        )
+
+        self.output("object data:", verbose_level=2)
+        self.output(template_contents, verbose_level=2)
+
+        # write the template to temp file
+        template_file = self.write_temp_file(template_contents)
+        return object_name, template_file
 
     class ParseHTMLForError(HTMLParser):  # pylint: disable=abstract-method
         """Parses HTML output for the appropriate error"""

--- a/JamfUploaderProcessors/READMEs/JamfObjectReader.md
+++ b/JamfUploaderProcessors/READMEs/JamfObjectReader.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-A processor for AutoPkg to read an API object and output to file (XML or JSON depending on whether the Classic or Jamf Pro API is used.)
+A processor for AutoPkg to read an API object and optionally, output to file (XML or JSON depending on whether the Classic or Jamf Pro API is used). Optionally, all objects of a single type may be downloaded in one operation. Additionally, Scripts, Extension Attributes and Mobileconfig files are extracted from the XML and saved as separate files.
 
 ## Input variables
 
@@ -33,10 +33,13 @@ A processor for AutoPkg to read an API object and output to file (XML or JSON de
 - **output_path**:
   - **required**: False
   - **description**: Path to dump the xml or json file.
+- **elements_to_remove**:
+  - **required**: False
+  - **description**: A list of XML or JSON elements that should be removed from the downloaded XML. Note that `id` and `self_service_icon` are removed automatically.
 
 ## Output variables
 
-- **jamfclassicapiobjectuploader_summary_result:**
+- **jamfobjectreader_summary_result:**
   - **description:** Description of interesting results.
 - **object_name**:
   - **description**: The name of the API object

--- a/JamfUploaderProcessors/READMEs/JamfObjectUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfObjectUploader.md
@@ -30,6 +30,9 @@ A processor for AutoPkg that will upload various Classic API or Jamf Pro API obj
 - **object_type**:
   - **required**: True
   - **description**: The API object type. This is in the singular form - for Classic API endpoints this is the name of the key in the XML template. For JSON objects it is a construction made interally for this project. See the [Object Reference](./Object%20Reference.md) for valid objects.
+- **elements_to_remove**:
+  - **required**: False
+  - **description**: A list of XML or JSON elements that should be removed from the downloaded XML. Note that `id` and `self_service_icon` are removed automatically.
 - **replace_object**:
   - **required**: False
   - **description**: overwrite an existing Computer Group if True.
@@ -41,7 +44,7 @@ A processor for AutoPkg that will upload various Classic API or Jamf Pro API obj
 
 ## Output variables
 
-- **jamfclassicapiobjectuploader_summary_result:**
+- **jamfobjectuploader_summary_result:**
   - **description:** Description of interesting results.
 - **object_name**:
   - **description**: The name of the API object

--- a/_tests/_ParseAndUploadTest.jamf.recipe.yaml
+++ b/_tests/_ParseAndUploadTest.jamf.recipe.yaml
@@ -1,0 +1,18 @@
+Identifier: com.github.grahampugh.recipes.tests.ParseAndUpload
+MinimumVersion: "2.3"
+
+Input: {}
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfObjectUploader
+    Arguments:
+      object_name: Firefox
+      object_type: policy
+      object_template: /Users/Shared/Jamf/JamfUploaderTests/jssimporter-policies-Firefox.xml
+      elements_to_remove:
+        - scope
+        - category
+        - self_service
+        - trigger_checkin
+        - frequency
+      replace_object: True

--- a/_tests/_ReadAndParseTest.jamf.recipe.yaml
+++ b/_tests/_ReadAndParseTest.jamf.recipe.yaml
@@ -1,0 +1,16 @@
+Identifier: com.github.grahampugh.recipes.ReadAndParse
+MinimumVersion: "2.3"
+
+Input: {}
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfObjectReader
+    Arguments:
+      object_name: Firefox
+      object_type: policy
+      output_path: /Users/Shared/Jamf/JamfUploaderTests
+      elements_to_remove:
+        - limit_to_users
+        - site
+        - buildings
+        - departments

--- a/_tests/_ReadAndParseTest.jamf.recipe.yaml
+++ b/_tests/_ReadAndParseTest.jamf.recipe.yaml
@@ -1,4 +1,4 @@
-Identifier: com.github.grahampugh.recipes.ReadAndParse
+Identifier: com.github.grahampugh.recipes.tests.ReadAndParse
 MinimumVersion: "2.3"
 
 Input: {}
@@ -10,7 +10,4 @@ Process:
       object_type: policy
       output_path: /Users/Shared/Jamf/JamfUploaderTests
       elements_to_remove:
-        - limit_to_users
         - site
-        - buildings
-        - departments


### PR DESCRIPTION
This removes the automatic parsing of specific objects (other than ID and self_service_icon), and allows a list of elements to be provided that will be removed.

Both JamfObjectReader and JamfObjectUploader gain this functionality, allowing the use of raw downloaded XML objects from any source to be parsed on Upload, or the steripping out of unnecessary keys en masse during download. 