### PR TITLE
Update JamfUploaderBase.py

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -1021,7 +1021,9 @@ class JamfUploaderBase(Processor):
             return parsed_xml.decode("UTF-8")
         else:
             # do json stuff
-            # remove any id-type tags
+            existing_object = json.loads(existing_object)
+
+            # remove any id-type tags            
             if "id" in existing_object:
                 existing_object.pop("id")
             if "categoryId" in existing_object:


### PR DESCRIPTION
Fixes the following when trying to upload an EA JSON object.
```
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 626, in process
    self.main()
  File "/Users/Shared/GitHub/jamf-upload/JamfUploaderProcessors/JamfObjectUploader.py", line 122, in main
    self.execute()
  File "/Users/Shared/GitHub/jamf-upload/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py", line 132, in execute
    object_name, template_file = self.prepare_template(
  File "/Users/Shared/GitHub/jamf-upload/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py", line 1056, in prepare_template
    template_contents = self.parse_downloaded_api_object(
  File "/Users/Shared/GitHub/jamf-upload/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py", line 1032, in parse_downloaded_api_object
    for elem in existing_object.values():
AttributeError: 'str' object has no attribute 'values'
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
'str' object has no attribute 'values'
```