### PR TITLE
JamfScopeAdjuster

### DIFF
--- a/JamfUploaderProcessors/JamfAPIClientUploader.py
+++ b/JamfUploaderProcessors/JamfAPIClientUploader.py
@@ -1,4 +1,5 @@
 #!/usr/local/autopkg/python
+# pylint: disable=invalid-name
 
 """
 Copyright 2025 Graham Pugh

--- a/JamfUploaderProcessors/JamfAPIRoleUploader.py
+++ b/JamfUploaderProcessors/JamfAPIRoleUploader.py
@@ -1,4 +1,5 @@
 #!/usr/local/autopkg/python
+# pylint: disable=invalid-name
 
 """
 Copyright 2023 Graham Pugh

--- a/JamfUploaderProcessors/JamfObjectReader.py
+++ b/JamfUploaderProcessors/JamfObjectReader.py
@@ -93,9 +93,9 @@ class JamfObjectReader(JamfObjectReaderBase):
             "description": "Type of the object. This is the name of the key in the XML template",
             "default": "",
         },
-        "output_path": {
+        "output_dir": {
             "required": False,
-            "description": "Path (folder) to dump the xml or json file",
+            "description": "Output directory to dump the xml or json file",
             "default": "",
         },
         "elements_to_remove": {
@@ -125,7 +125,7 @@ class JamfObjectReader(JamfObjectReaderBase):
         "parsed_object": {
             "description": "String containing parsed XML (removes IDs and computers)",
         },
-        "output_path": {
+        "output_dir": {
             "description": "Path of dumped xml",
         },
     }

--- a/JamfUploaderProcessors/JamfScopeAdjuster.py
+++ b/JamfUploaderProcessors/JamfScopeAdjuster.py
@@ -1,4 +1,5 @@
 #!/usr/local/autopkg/python
+# pylint: disable=invalid-name
 
 """
 2025 Neil Martin
@@ -27,12 +28,16 @@ import sys
 # imports require noqa comments for E402
 sys.path.insert(0, os.path.dirname(__file__))
 
-from JamfUploaderLib.JamfScopeAdjusterBase import JamfScopeAdjusterBase  # noqa: E402
+from JamfUploaderLib.JamfScopeAdjusterBase import (  # pylint: disable=import-error, wrong-import-position
+    JamfScopeAdjusterBase,
+)
 
 __all__ = ["JamfScopeAdjuster"]
 
 
 class JamfScopeAdjuster(JamfScopeAdjusterBase):
+    """Processor to adjust the scope of a Jamf object"""
+
     description = (
         "AutoPkg processor that adds or removes a scopeable object as a target, "
         "limitation or exclusion to or from a Jamf API object."
@@ -41,58 +46,75 @@ class JamfScopeAdjuster(JamfScopeAdjusterBase):
     input_variables = {
         "object_template": {
             "required": False,
-            "description": "Full path of the object file to modify."
+            "description": "Full path of the object file to modify.",
         },
         "raw_object": {
             "required": False,
-            "description": '''XML object string to modify. Used if object_template is not supplied, 
-                            e.g. if taking input from JamfObjectReader.'''
+            "description": (
+                "XML object string to modify. Used if object_template is not supplied, "
+                "e.g. if taking input from JamfObjectReader."
+            ),
         },
         "scoping_operation": {
             "required": True,
-            "description": "Specify 'add' or 'remove'."
+            "description": "Specify 'add' or 'remove'.",
         },
         "scoping_type": {
             "required": True,
-            "description": "Type of scope. Specify 'target', 'limitation' or 'exclusion'."
+            "description": "Type of scope. Specify 'target', 'limitation' or 'exclusion'.",
         },
-        "scopable_type": {
+        "scopeable_type": {
             "required": True,
-            "description": "Type of scopeable object. Specify 'user_group', 'computer_group' 'mobile_device_group'."
+            "description": (
+                "Type of scopeable object. Specify 'user_group', 'computer_group' "
+                "'mobile_device_group'."
+            ),
         },
         "scopeable_name": {
             "required": True,
-            "description": "Name of scobeable object."
+            "description": "Name of scopeable object.",
         },
         "strict_mode": {
             "required": False,
-            "description": '''Raise a ProcessrError when adding a scopable object that already exists
-                            or removing a scopable object that does not exist in the raw object.
-                            If set to False, continue without changing the raw object.
-                            Whilst this is safe and will not write unintended changes to the Jamf API,
-                            errors/oversights in specifying scopable object names may go unnoticed.''',
-            "default": "True"
+            "description": (
+                "Raise a ProcessorError when adding a scopable object that already exists "
+                "or removing a scopable object that does not exist in the raw object. "
+                "If set to False, continue without changing the raw object. "
+                "Whilst this is safe and will not write unintended changes to the Jamf API, "
+                "errors/oversights in specifying scopable object names may go unnoticed."
+            ),
+            "default": "True",
         },
         "strip_raw_xml": {
             "required": False,
-            "description": '''Strip all XML tags except for general/id and scope. Set to True if input 
-                            is from JamfObjectReader raw_object (default). Ensures only scope is written 
-                            back to the Jamf API. Set to False if input is from object_template file.''',
-            "default": "True"
+            "description": (
+                "Strip all XML tags except for general/id and scope. Set to True if input "
+                "is from JamfObjectReader raw_object (default). Ensures only scope is written "
+                "back to the Jamf API. Set to False if input is from object_template file."
+            ),
+            "default": "True",
         },
         "output_dir": {
             "required": False,
-            "description": "Directory to save the modified object file. Defaults to RECIPE_CACHE_DIR."
-        }
+            "description": (
+                "Directory to save the modified object file. Defaults to RECIPE_CACHE_DIR."
+            ),
+        },
     }
-    
+
     output_variables = {
         "object_template": {
-            "description": "Full path of the modified object file. Intended to pass to JamfObjectUploader."
+            "description": (
+                "Full path of the modified object file. Intended to pass to "
+                "JamfObjectUploader."
+            )
         },
         "raw_object": {
-            "description": "Raw processed XML object string. For chaining additional JamfScopeAdjuster processors."
-        }
+            "description": (
+                "Raw processed XML object string. For chaining additional "
+                "JamfScopeAdjuster processors."
+            )
+        },
     }
 
     def main(self):

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -49,7 +49,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
         object_name = self.env.get("object_name")
         all_objects = self.env.get("all_objects")
         object_type = self.env.get("object_type")
-        output_path = self.env.get("output_path")
+        output_dir = self.env.get("output_dir")
         elements_to_remove = self.env.get("elements_to_remove")
         if isinstance(elements_to_remove, str):
             elements_to_remove = [elements_to_remove]
@@ -108,7 +108,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
         elif all_objects:
             object_list = self.get_all_api_objects(jamf_url, object_type, token)
             # we really need an output path for all_objects, so exit if not provided
-            if not output_path:
+            if not output_dir:
                 self.output("ERROR: no output path provided")
                 return
 
@@ -151,8 +151,8 @@ class JamfObjectReaderBase(JamfUploaderBase):
                 )
                 payload_filetype = "mobileconfig"
 
-            # dump the object to file is output_path is specified
-            if output_path:
+            # dump the object to file is output_dir is specified
+            if output_dir:
                 # construct the filename
                 if "JSSResource" in self.api_endpoints(object_type):
                     filetype = "xml"
@@ -165,9 +165,9 @@ class JamfObjectReaderBase(JamfUploaderBase):
                 output_filename = (
                     f"{subdomain}-{self.object_list_types(object_type)}-{n}.{filetype}"
                 )
-                file_path = os.path.join(output_path, output_filename)
+                file_path = os.path.join(output_dir, output_filename)
                 # check that parent folder exists
-                if os.path.isdir(output_path):
+                if os.path.isdir(output_dir):
                     try:
                         with open(file_path, "w", encoding="utf-8") as fp:
                             fp.write(parsed_object)
@@ -179,7 +179,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
                                 f".{payload_filetype}"
                             )
                             payload_file_path = os.path.join(
-                                output_path, payload_output_filename
+                                output_dir, payload_output_filename
                             )
                             with open(payload_file_path, "w", encoding="utf-8") as fp:
                                 fp.write(payload)
@@ -193,12 +193,12 @@ class JamfObjectReaderBase(JamfUploaderBase):
                         ) from e
                 else:
                     self.output(
-                        f"Cannot write to {output_path} as the folder doesn't exist"
+                        f"Cannot write to {output_dir} as the folder doesn't exist"
                     )
 
         # output the summary
         self.env["object_type"] = object_type
-        self.env["output_path"] = output_path
+        self.env["output_dir"] = output_dir
         if not all_objects:
             self.env["object_name"] = object_name
             self.env["object_id"] = obj_id

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -1017,9 +1017,10 @@ class JamfUploaderBase(Processor):
                 # remove any self service icons
                 self.remove_elements_from_xml(object_xml, "self_service_icon")
                 # optional array of other elements to remove
-                for elem in elements_to_remove:
-                    self.output(f"Deleting element {elem}...", verbose_level=2)
-                    self.remove_elements_from_xml(object_xml, elem)
+                if elements_to_remove is not None:
+                    for elem in elements_to_remove:
+                        self.output(f"Deleting element {elem}...", verbose_level=2)
+                        self.remove_elements_from_xml(object_xml, elem)
 
                 # for profiles ensure that they are redeployed to all
                 self.substitute_elements_in_xml(object_xml, "redeploy_on_update", "All")
@@ -1028,24 +1029,23 @@ class JamfUploaderBase(Processor):
             except ET.ParseError as xml_error:
                 raise ProcessorError from xml_error
             return parsed_xml.decode("UTF-8")
-        else:
-            # do json stuff
-            existing_object = json.loads(existing_object)
+        # do json stuff
+        existing_object = json.loads(existing_object)
 
-            # remove any id-type tags            
-            if "id" in existing_object:
-                existing_object.pop("id")
-            if "categoryId" in existing_object:
-                existing_object.pop("categoryId")
-            if "deviceEnrollmentProgramInstanceId" in existing_object:
-                existing_object.pop("deviceEnrollmentProgramInstanceId")
-            # now go one deep and look for more id keys. Hopefully we don't have to go deeper!
-            for elem in existing_object.values():
-                elem_check = elem
-                if isinstance(elem_check, abc.Mapping):
-                    if "id" in elem:
-                        elem.pop("id")
-            return json.dumps(existing_object, indent=4)
+        # remove any id-type tags
+        if "id" in existing_object:
+            existing_object.pop("id")
+        if "categoryId" in existing_object:
+            existing_object.pop("categoryId")
+        if "deviceEnrollmentProgramInstanceId" in existing_object:
+            existing_object.pop("deviceEnrollmentProgramInstanceId")
+        # now go one deep and look for more id keys. Hopefully we don't have to go deeper!
+        for elem in existing_object.values():
+            elem_check = elem
+            if isinstance(elem_check, abc.Mapping):
+                if "id" in elem:
+                    elem.pop("id")
+        return json.dumps(existing_object, indent=4)
 
     def prepare_template(
         self,

--- a/JamfUploaderProcessors/READMEs/JamfObjectDeleter.md
+++ b/JamfUploaderProcessors/READMEs/JamfObjectDeleter.md
@@ -1,4 +1,4 @@
-# JamfObjectReader
+# JamfObjectDeleter
 
 ## Description
 
@@ -24,27 +24,13 @@ A processor for AutoPkg to delete an API object.
 - **object_name**:
   - **required**: False
   - **description**: The name of the API object
-- **object_template**:
-  - **required**: True
-  - **description**: Path to the API object template file
 - **object_type**:
   - **required**: True
   - **description**: The API object type. This is in the singular form - the name of the key in the XML template. See the [Object Reference](./Object%20Reference.md) for valid objects.
-- **output_path**:
-  - **required**: False
-  - **description**: Path to dump the xml or json file.
 
 ## Output variables
 
-- **jamfclassicapiobjectuploader_summary_result:**
+- **jamfobjectdeleter_summary_result:**
   - **description:** Description of interesting results.
 - **object_name**:
   - **description**: The name of the API object
-- **object_id**:
-  - **description**: The ID of the API object
-- **raw_object**:
-  - **description**: String containing the complete raw downloaded XML
-- **parsed_object**:
-  - **description**: String containing parsed XML (removes IDs and computers)
-- **output_path**:
-  - **description**: Path the xml or json file was saved to.

--- a/JamfUploaderProcessors/READMEs/JamfObjectReader.md
+++ b/JamfUploaderProcessors/READMEs/JamfObjectReader.md
@@ -30,9 +30,9 @@ A processor for AutoPkg to read an API object and optionally, output to file (XM
 - **object_type**:
   - **required**: True
   - **description**: The API object type. This is in the singular form - the name of the key in the XML template. See the [Object Reference](./Object%20Reference.md) for valid objects.
-- **output_path**:
+- **output_dir**:
   - **required**: False
-  - **description**: Path to dump the xml or json file.
+  - **description**: Output directory to dump the xml or json file.
 - **elements_to_remove**:
   - **required**: False
   - **description**: A list of XML or JSON elements that should be removed from the downloaded XML. Note that `id` and `self_service_icon` are removed automatically.
@@ -49,5 +49,5 @@ A processor for AutoPkg to read an API object and optionally, output to file (XM
   - **description**: String containing the complete raw downloaded XML
 - **parsed_object**:
   - **description**: String containing parsed XML (removes IDs and computers)
-- **output_path**:
-  - **description**: Path the xml or json file was saved to.
+- **output_dir**:
+  - **description**: Directory the xml or json file was saved to.

--- a/JamfUploaderProcessors/READMEs/JamfScopeAdjuster.md
+++ b/JamfUploaderProcessors/READMEs/JamfScopeAdjuster.md
@@ -18,7 +18,7 @@ A processor for AutoPkg that adds or removes a scopeable object (target, limitat
 - **scoping_type:**  
   - **required:** True  
   - **description:** Type of scope. Specify `target`, `limitation`, or `exclusion`.
-- **scopable_type:**  
+- **scopeable_type:**  
   - **required:** True  
   - **description:** Type of scopeable object. Specify `user_group`, `computer_group`, or `mobile_device_group`.
 - **scopeable_name:**  

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -47,6 +47,22 @@ if [[ $test_type == "ldap_server" ]]; then
         "$verbosity" \
         --replace
 
+elif [[ $test_type == "scope" ]]; then
+    # adjust a scope
+    "$DIR"/../jamf-upload.sh scope \
+        --prefs "$prefs" \
+        --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
+        --name "d.ethz.ch" \
+        --template "/Users/Shared/Jamf/JamfUploaderTests/jssimporter-policies-Firefox.xml" \
+        --scope-type "target" \
+        --operation "remove" \
+        --type "computer_group" \
+        --name "Testing" \
+        --output "/Users/Shared/Jamf/JamfUploaderTests" \
+        --not-strict \
+        "$verbosity"
+
+
 # example object types (Classic API)
 # computer_group
 # os_x_configuration_profile

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -52,7 +52,6 @@ elif [[ $test_type == "scope" ]]; then
     "$DIR"/../jamf-upload.sh scope \
         --prefs "$prefs" \
         --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
-        --name "d.ethz.ch" \
         --template "/Users/Shared/Jamf/JamfUploaderTests/jssimporter-policies-Firefox.xml" \
         --scope-type "target" \
         --operation "remove" \


### PR DESCRIPTION
@neilmartin83 in case you want to look at the linting.

I used Copilot a bit to help shorten the lines and add descriptions to functions that lacked one.

I approved the use of `output_dir`, so this now replaces `output_path` in `JamfObjectReader` - any existing recipes/scripts will have to be adjusted. This is because in other processors, `output_path` refers to the complete path to a file, not just to a directory.

`scopeable_type` replaces `scopable_type` so that it matches `scopeable_name`. Or the other way around, I forget now!

I added an output line that says where the file was outputted to. The rest of the PR are other minor lints and typos I came across.
