### PR TITLE
Jamf extension attribute popup choice adjuster

### DIFF
--- a/JamfUploaderProcessors/JamfExtensionAttributePopupChoiceAdjuster.py
+++ b/JamfUploaderProcessors/JamfExtensionAttributePopupChoiceAdjuster.py
@@ -1,4 +1,5 @@
 #!/usr/local/autopkg/python
+# pylint: disable=invalid-name
 
 """
 2025 Neil Martin
@@ -27,39 +28,39 @@ import sys
 # imports require noqa comments for E402
 sys.path.insert(0, os.path.dirname(__file__))
 
-from JamfUploaderLib.JamfExtensionAttributePopupChoiceAdjusterBase import (  # noqa: E402
+from JamfUploaderLib.JamfExtensionAttributePopupChoiceAdjusterBase import (  # pylint: disable=import-error, wrong-import-position
     JamfExtensionAttributePopupChoiceAdjusterBase,
 )
 
 __all__ = ["JamfExtensionAttributePopupChoiceAdjuster"]
 
 
-class JamfExtensionAttributePopupChoiceAdjuster(JamfExtensionAttributePopupChoiceAdjusterBase):
+class JamfExtensionAttributePopupChoiceAdjuster(
+    JamfExtensionAttributePopupChoiceAdjusterBase
+):
     """AutoPkg processor that adds or removes pop-up choices from a Jamf Extension Attribute."""
 
-    description = (
-        "AutoPkg processor that adds or removes pop-up choices from a Jamf Extension Attribute."
-    )
+    description = "AutoPkg processor that adds or removes pop-up choices from a Jamf Extension Attribute."
 
     input_variables = {
         "object_template": {
             "required": False,
-            "description": "Full path of the object file to modify."
+            "description": "Full path of the object file to modify.",
         },
         "parsed_object": {
             "required": False,
             "description": (
                 "XML or JSON parsed object string to modify. Used if object_template "
                 "is not supplied, e.g. if taking input from JamfObjectReader."
-            )
+            ),
         },
         "choice_operation": {
             "required": True,
-            "description": "Specify 'add' to add a choice or 'remove' to remove a choice."
+            "description": "Specify 'add' to add a choice or 'remove' to remove a choice.",
         },
         "choice_value": {
             "required": True,
-            "description": "Pop-up choice value to add or remove."
+            "description": "Pop-up choice value to add or remove.",
         },
         "strict_mode": {
             "required": False,
@@ -70,14 +71,14 @@ class JamfExtensionAttributePopupChoiceAdjuster(JamfExtensionAttributePopupChoic
                 "unintended changes to the Jamf API, errors/oversights in specifying choice names "
                 "may go unnoticed."
             ),
-            "default": "True"
+            "default": "True",
         },
         "output_dir": {
             "required": False,
             "description": (
                 "Directory to save the modified XML or JSON file. Defaults to RECIPE_CACHE_DIR."
-            )
-        }
+            ),
+        },
     }
 
     output_variables = {
@@ -91,7 +92,7 @@ class JamfExtensionAttributePopupChoiceAdjuster(JamfExtensionAttributePopupChoic
                 "Parsed processed object string. For chaining additional "
                 "JamfExtensionAttributePopupChoiceAdjuster processors."
             )
-        }
+        },
     }
 
     def main(self):

--- a/JamfUploaderProcessors/JamfExtensionAttributePopupChoiceAdjuster.py
+++ b/JamfUploaderProcessors/JamfExtensionAttributePopupChoiceAdjuster.py
@@ -1,0 +1,104 @@
+#!/usr/local/autopkg/python
+
+"""
+2025 Neil Martin
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+NOTES:
+All functions are in JamfUploaderLib/JamfExtensionAttributePopupChoiceAdjusterBase.py
+"""
+
+import os
+import sys
+
+# to use a base module in AutoPkg we need to add this path to the sys.path.
+# this violates flake8 E402 (PEP8 imports) but is unavoidable, so the following
+# imports require noqa comments for E402
+sys.path.insert(0, os.path.dirname(__file__))
+
+from JamfUploaderLib.JamfExtensionAttributePopupChoiceAdjusterBase import (  # noqa: E402
+    JamfExtensionAttributePopupChoiceAdjusterBase,
+)
+
+__all__ = ["JamfExtensionAttributePopupChoiceAdjuster"]
+
+
+class JamfExtensionAttributePopupChoiceAdjuster(JamfExtensionAttributePopupChoiceAdjusterBase):
+    """AutoPkg processor that adds or removes pop-up choices from a Jamf Extension Attribute."""
+
+    description = (
+        "AutoPkg processor that adds or removes pop-up choices from a Jamf Extension Attribute."
+    )
+
+    input_variables = {
+        "object_template": {
+            "required": False,
+            "description": "Full path of the object file to modify."
+        },
+        "parsed_object": {
+            "required": False,
+            "description": (
+                "XML or JSON parsed object string to modify. Used if object_template "
+                "is not supplied, e.g. if taking input from JamfObjectReader."
+            )
+        },
+        "choice_operation": {
+            "required": True,
+            "description": "Specify 'add' to add a choice or 'remove' to remove a choice."
+        },
+        "choice_value": {
+            "required": True,
+            "description": "Pop-up choice value to add or remove."
+        },
+        "strict_mode": {
+            "required": False,
+            "description": (
+                "Raise a ProcessorError when adding a choice that already exists "
+                "or removing a choice that does not exist in the parsed object. If set to False, "
+                "continue without changing the parsed object. Whilst this is safe and will not write "
+                "unintended changes to the Jamf API, errors/oversights in specifying choice names "
+                "may go unnoticed."
+            ),
+            "default": "True"
+        },
+        "output_dir": {
+            "required": False,
+            "description": (
+                "Directory to save the modified XML or JSON file. Defaults to RECIPE_CACHE_DIR."
+            )
+        }
+    }
+
+    output_variables = {
+        "object_template": {
+            "description": (
+                "Full path of the modified object file. Intended to pass to JamfObjectUploader."
+            )
+        },
+        "parsed_object": {
+            "description": (
+                "Parsed processed object string. For chaining additional "
+                "JamfExtensionAttributePopupChoiceAdjuster processors."
+            )
+        }
+    }
+
+    def main(self):
+        """Run the execute function"""
+        self.execute()
+
+
+if __name__ == "__main__":
+    PROCESSOR = JamfExtensionAttributePopupChoiceAdjuster()
+    PROCESSOR.execute_shell()

--- a/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
+++ b/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
@@ -74,19 +74,22 @@ class JamfExtensionAttributeUploader(JamfExtensionAttributeUploaderBase):
             "description": "Extension Attribute name",
             "default": "",
         },
+        "ea_input_type": {
+            "required": False,
+            "description": ("Type of EA. One of script, popup, text, or ldap."),
+            "default": "script",
+        },
         "ea_script_path": {
             "required": False,
             "description": "Full path to the script to be uploaded",
         },
-        "replace_ea": {
-            "required": False,
-            "description": "Overwrite an existing category if True.",
-            "default": False,
-        },
         "ea_inventory_display": {
             "required": False,
-            "description": "Inventory Display value for the EA.",
-            "default": "Extension Attributes",
+            "description": (
+                "Inventory Display value for the EA. One of GENERAL, HARDWARE, "
+                "OPERATING_SYSTEM, USER_AND_LOCATION, PURCHASING, EXTENSION_ATTRIBUTES."
+            ),
+            "default": "EXTENSION_ATTRIBUTES",
         },
         "ea_data_type": {
             "required": False,
@@ -96,11 +99,24 @@ class JamfExtensionAttributeUploader(JamfExtensionAttributeUploaderBase):
         "ea_description": {
             "required": False,
             "description": "Description for the EA.",
-            "default": "String",
+        },
+        "ea_directory_service_attribute_mapping": {
+            "required": False,
+            "description": "Directory Service (LDAP) attribute mapping. Currently this must be manaully set.",
+        },
+        "ea_enabled": {
+            "required": False,
+            "description": "String-based EAs can be disabled.",
+            "default": True,
         },
         "skip_script_key_substitution": {
             "required": False,
             "description": "Skip key substitution in processing the script",
+            "default": False,
+        },
+        "replace_ea": {
+            "required": False,
+            "description": "Overwrite an existing category if True.",
             "default": False,
         },
         "sleep": {

--- a/JamfUploaderProcessors/JamfMobileDeviceExtensionAttributeUploader.py
+++ b/JamfUploaderProcessors/JamfMobileDeviceExtensionAttributeUploader.py
@@ -1,7 +1,8 @@
 #!/usr/local/autopkg/python
+# pylint: disable=invalid-name
 
 """
-Copyright 2023 Graham Pugh
+Copyright 2025 Graham Pugh
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 NOTES:
-All functions are in JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
+All functions are in JamfUploaderLib/JamfMobileDeviceExtensionAttributeUploaderBase.py
 """
 
 import os
@@ -27,14 +28,16 @@ import sys
 # imports require noqa comments for E402
 sys.path.insert(0, os.path.dirname(__file__))
 
-from JamfUploaderLib.JamfExtensionAttributeUploaderBase import (  # noqa: E402
-    JamfExtensionAttributeUploaderBase,
+from JamfUploaderLib.JamfMobileDeviceExtensionAttributeUploaderBase import (  # pylint: disable=import-error, wrong-import-position
+    JamfMobileDeviceExtensionAttributeUploaderBase,
 )
 
-__all__ = ["JamfExtensionAttributeUploader"]
+__all__ = ["JamfMobileDeviceExtensionAttributeUploader"]
 
 
-class JamfExtensionAttributeUploader(JamfExtensionAttributeUploaderBase):
+class JamfMobileDeviceExtensionAttributeUploader(
+    JamfMobileDeviceExtensionAttributeUploaderBase
+):
     description = (
         "A processor for AutoPkg that will upload an Extension Attribute item to a "
         "Jamf Cloud or on-prem server."
@@ -76,12 +79,8 @@ class JamfExtensionAttributeUploader(JamfExtensionAttributeUploaderBase):
         },
         "ea_input_type": {
             "required": False,
-            "description": ("Type of EA. One of script, popup, text, or ldap."),
-            "default": "script",
-        },
-        "ea_script_path": {
-            "required": False,
-            "description": "Full path to the script to be uploaded",
+            "description": ("Type of EA. One of popup, text, or ldap."),
+            "default": "text",
         },
         "ea_popup_choices": {
             "required": False,
@@ -111,16 +110,6 @@ class JamfExtensionAttributeUploader(JamfExtensionAttributeUploaderBase):
                 "Currently this must be manaully set."
             ),
         },
-        "ea_enabled": {
-            "required": False,
-            "description": "String-based EAs can be disabled.",
-            "default": True,
-        },
-        "skip_script_key_substitution": {
-            "required": False,
-            "description": "Skip key substitution in processing the script",
-            "default": False,
-        },
         "replace_ea": {
             "required": False,
             "description": "Overwrite an existing category if True.",
@@ -134,7 +123,7 @@ class JamfExtensionAttributeUploader(JamfExtensionAttributeUploaderBase):
     }
 
     output_variables = {
-        "jamfextensionattributeuploader_summary_result": {
+        "jamfmobiledeviceextensionattributeuploader_summary_result": {
             "description": "Description of interesting results.",
         },
     }
@@ -146,5 +135,5 @@ class JamfExtensionAttributeUploader(JamfExtensionAttributeUploaderBase):
 
 
 if __name__ == "__main__":
-    PROCESSOR = JamfExtensionAttributeUploader()
+    PROCESSOR = JamfMobileDeviceExtensionAttributeUploader()
     PROCESSOR.execute_shell()

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributePopupChoiceAdjusterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributePopupChoiceAdjusterBase.py
@@ -76,15 +76,21 @@ class JamfExtensionAttributePopupChoiceAdjusterBase(JamfUploaderBase):
         if is_json:
             data = json.loads(parsed_object)
 
-            if data.get('inputType') != 'POPUP':
-                raise ProcessorError("Invalid Extension Attribute inputType, must be POPUP.")
+            if data.get("inputType") != "POPUP":
+                raise ProcessorError(
+                    "Invalid Extension Attribute inputType, must be POPUP."
+                )
         else:
             root = ET.fromstring(parsed_object)
 
             if root.find(".//input_type/type").text != "Pop-up Menu":
-                raise ProcessorError("Invalid Extension Attribute input_type, must be Pop-up Menu.")
+                raise ProcessorError(
+                    "Invalid Extension Attribute input_type, must be Pop-up Menu."
+                )
 
-    def add_xml_tag(self, parsed_object, parent_xpath, element, choice_value, strict_mode):
+    def add_xml_tag(
+        self, parsed_object, parent_xpath, element, choice_value, strict_mode
+    ):  # pylint: disable=too-many-arguments
         """
         Add an XML tag to the parsed object.
 
@@ -113,8 +119,10 @@ class JamfExtensionAttributePopupChoiceAdjusterBase(JamfUploaderBase):
                     f"WARNING: Element <{element}> with choice_value '{choice_value}' already exists "
                     f"in {parent_xpath}, parsed object unchanged."
                 )
-                return ET.tostring(root, encoding="UTF-8", xml_declaration=True).decode()
-            elif child.text == choice_value:
+                return ET.tostring(
+                    root, encoding="UTF-8", xml_declaration=True
+                ).decode()
+            if child.text == choice_value:
                 raise ProcessorError(
                     f"Element <{element}> with choice_value '{choice_value}' already exists in "
                     f"{parent_xpath}"
@@ -124,7 +132,9 @@ class JamfExtensionAttributePopupChoiceAdjusterBase(JamfUploaderBase):
         new_tag.text = choice_value
         parent.append(new_tag)
 
-        self.output(f"Added element <{element}> and choice_value '{choice_value}' to {parent_xpath}")
+        self.output(
+            f"Added element <{element}> and choice_value '{choice_value}' to {parent_xpath}"
+        )
         return ET.tostring(root, encoding="UTF-8", xml_declaration=True).decode()
 
     def remove_xml_tag(self, parsed_object, element, choice_value, strict_mode):
@@ -153,11 +163,13 @@ class JamfExtensionAttributePopupChoiceAdjusterBase(JamfUploaderBase):
                     removed = True
 
         if removed:
-            self.output(f"Removed all instances of <{element}> containing '{choice_value}' from XML.")
+            self.output(
+                f"Removed all instances of <{element}> containing '{choice_value}' from XML."
+            )
         elif strict_mode == "False":
             self.output(
-                f"WARNING: Element <{element}> with choice_value '{choice_value}' not found, parsed "
-                f"object unchanged."
+                f"WARNING: Element <{element}> with choice_value '{choice_value}' not found, "
+                "parsed object unchanged."
             )
         else:
             raise ProcessorError(
@@ -192,7 +204,7 @@ class JamfExtensionAttributePopupChoiceAdjusterBase(JamfUploaderBase):
                         f"parsed object unchanged."
                     )
                     return json.dumps(data, indent=4)
-                elif choice_value in data[element]:
+                if choice_value in data[element]:
                     raise ProcessorError(
                         f"choice_value '{choice_value}' already exists in array '{element}'."
                     )
@@ -278,7 +290,9 @@ class JamfExtensionAttributePopupChoiceAdjusterBase(JamfUploaderBase):
         if strict_mode == "False":
             self.output("WARNING: Strict mode disabled!")
 
-        is_json = parsed_object.strip().startswith("{") or parsed_object.strip().startswith("[")
+        is_json = parsed_object.strip().startswith(
+            "{"
+        ) or parsed_object.strip().startswith("[")
         self.validate_ea_type(is_json, parsed_object)
 
         if object_template:
@@ -293,34 +307,21 @@ class JamfExtensionAttributePopupChoiceAdjusterBase(JamfUploaderBase):
             parent_xpath = "./input_type/popup_choices"
             if choice_operation == "add":
                 parsed_object = self.add_xml_tag(
-                    parsed_object,
-                    parent_xpath,
-                    element,
-                    choice_value,
-                    strict_mode
+                    parsed_object, parent_xpath, element, choice_value, strict_mode
                 )
             elif choice_operation == "remove":
                 parsed_object = self.remove_xml_tag(
-                    parsed_object,
-                    element,
-                    choice_value,
-                    strict_mode
+                    parsed_object, element, choice_value, strict_mode
                 )
         elif is_json:
             element = "popupMenuChoices"
             if choice_operation == "add":
                 parsed_object = self.add_json_key(
-                    parsed_object,
-                    element,
-                    choice_value,
-                    strict_mode
+                    parsed_object, element, choice_value, strict_mode
                 )
             elif choice_operation == "remove":
                 parsed_object = self.remove_json_key(
-                    parsed_object,
-                    element,
-                    choice_value,
-                    strict_mode
+                    parsed_object, element, choice_value, strict_mode
                 )
         else:
             raise ProcessorError("Unsupported data format. Use XML or JSON.")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributePopupChoiceAdjusterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributePopupChoiceAdjusterBase.py
@@ -1,0 +1,332 @@
+#!/usr/local/autopkg/python
+# pylint: disable=invalid-name
+
+"""
+2025 Neil Martin
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import xml.etree.ElementTree as ET
+import json
+import os
+import sys
+
+from urllib.parse import urlparse
+
+from autopkglib import (  # pylint: disable=import-error
+    ProcessorError,
+)
+
+# to use a base module in AutoPkg we need to add this path to the sys.path.
+# this violates flake8 E402 (PEP8 imports) but is unavoidable, so the following
+# imports require noqa comments for E402
+sys.path.insert(0, os.path.dirname(__file__))
+
+from JamfUploaderBase import (  # pylint: disable=import-error, wrong-import-position
+    JamfUploaderBase,
+)
+
+
+class JamfExtensionAttributePopupChoiceAdjusterBase(JamfUploaderBase):
+    """Class for functions used to adjust an Extension Attribute Pop-up Choice"""
+
+    def generate_filename_from_object(self, is_json, parsed_object):
+        """
+        Generate a filename based on the object instance and name.
+
+        Args:
+            is_json (bool): Flag indicating if the object is in JSON format.
+            parsed_object (str): The parsed object string.
+
+        Returns:
+            str: The generated filename.
+        """
+        object_instance = urlparse(self.env.get("JSS_URL")).hostname.split(".")[0]
+        if is_json:
+            ext = ".json"
+            object_name = json.loads(parsed_object)["name"]
+        else:
+            ext = ".xml"
+            object_name = ET.fromstring(parsed_object).find("./name").text
+
+        return f"{object_instance}_{object_name}{ext}"
+
+    def validate_ea_type(self, is_json, parsed_object):
+        """
+        Validate the type of the extension attribute.
+
+        Args:
+            is_json (bool): Flag indicating if the object is in JSON format.
+            parsed_object (str): The parsed object string.
+
+        Raises:
+            ProcessorError: If the extension attribute type is invalid.
+        """
+        if is_json:
+            data = json.loads(parsed_object)
+
+            if data.get('inputType') != 'POPUP':
+                raise ProcessorError("Invalid Extension Attribute inputType, must be POPUP.")
+        else:
+            root = ET.fromstring(parsed_object)
+
+            if root.find(".//input_type/type").text != "Pop-up Menu":
+                raise ProcessorError("Invalid Extension Attribute input_type, must be Pop-up Menu.")
+
+    def add_xml_tag(self, parsed_object, parent_xpath, element, choice_value, strict_mode):
+        """
+        Add an XML tag to the parsed object.
+
+        Args:
+            parsed_object (str): The parsed object string.
+            parent_xpath (str): The XPath of the parent element.
+            element (str): The name of the element to add.
+            choice_value (str): The value of the choice to add.
+            strict_mode (str): Flag indicating if strict mode is enabled.
+
+        Returns:
+            str: The modified parsed object string.
+
+        Raises:
+            ProcessorError: If the parent element is not found or the element already exists.
+        """
+        root = ET.fromstring(parsed_object)
+        parent = root.find(parent_xpath)
+
+        if parent is None:
+            raise ProcessorError(f"Parent element not found for XPath: {parent_xpath}")
+
+        for child in parent.findall(element):
+            if child.text == choice_value and strict_mode == "False":
+                self.output(
+                    f"WARNING: Element <{element}> with choice_value '{choice_value}' already exists "
+                    f"in {parent_xpath}, parsed object unchanged."
+                )
+                return ET.tostring(root, encoding="UTF-8", xml_declaration=True).decode()
+            elif child.text == choice_value:
+                raise ProcessorError(
+                    f"Element <{element}> with choice_value '{choice_value}' already exists in "
+                    f"{parent_xpath}"
+                )
+
+        new_tag = ET.Element(element)
+        new_tag.text = choice_value
+        parent.append(new_tag)
+
+        self.output(f"Added element <{element}> and choice_value '{choice_value}' to {parent_xpath}")
+        return ET.tostring(root, encoding="UTF-8", xml_declaration=True).decode()
+
+    def remove_xml_tag(self, parsed_object, element, choice_value, strict_mode):
+        """
+        Remove an XML tag from the parsed object.
+
+        Args:
+            parsed_object (str): The parsed object string.
+            element (str): The name of the element to remove.
+            choice_value (str): The value of the choice to remove.
+            strict_mode (str): Flag indicating if strict mode is enabled.
+
+        Returns:
+            str: The modified parsed object string.
+
+        Raises:
+            ProcessorError: If the element is not found and strict mode is enabled.
+        """
+        root = ET.fromstring(parsed_object)
+        removed = False
+
+        for parent in list(root.iter()):
+            for child in list(parent):
+                if child.tag == element and child.text == choice_value:
+                    parent.remove(child)
+                    removed = True
+
+        if removed:
+            self.output(f"Removed all instances of <{element}> containing '{choice_value}' from XML.")
+        elif strict_mode == "False":
+            self.output(
+                f"WARNING: Element <{element}> with choice_value '{choice_value}' not found, parsed "
+                f"object unchanged."
+            )
+        else:
+            raise ProcessorError(
+                f"Element <{element}> with choice_value '{choice_value}' not found."
+            )
+
+        return ET.tostring(root, encoding="UTF-8", xml_declaration=True).decode()
+
+    def add_json_key(self, parsed_object, element, choice_value, strict_mode):
+        """
+        Add a key to the JSON object.
+
+        Args:
+            parsed_object (str): The parsed object string.
+            element (str): The name of the element to add.
+            choice_value (str): The value of the choice to add.
+            strict_mode (str): Flag indicating if strict mode is enabled.
+
+        Returns:
+            str: The modified parsed object string.
+
+        Raises:
+            ProcessorError: If the element already exists and strict mode is enabled.
+        """
+        data = json.loads(parsed_object)
+
+        if element in data:
+            if isinstance(data[element], list):
+                if choice_value in data[element] and strict_mode == "False":
+                    self.output(
+                        f"WARNING: choice_value '{choice_value}' already exists in array '{element}', "
+                        f"parsed object unchanged."
+                    )
+                    return json.dumps(data, indent=4)
+                elif choice_value in data[element]:
+                    raise ProcessorError(
+                        f"choice_value '{choice_value}' already exists in array '{element}'."
+                    )
+                data[element].append(choice_value)
+            else:
+                raise ProcessorError(f"Key '{element}' exists but is not an array.")
+        else:
+            data[element] = [choice_value]
+
+        self.output(f"Added choice_value '{choice_value}' to key '{element}' in JSON.")
+
+        return json.dumps(data, indent=4)
+
+    def remove_json_key(self, parsed_object, element, choice_value, strict_mode):
+        """
+        Remove a key from the JSON object.
+
+        Args:
+            parsed_object (str): The parsed object string.
+            element (str): The name of the element to remove.
+            choice_value (str): The value of the choice to remove.
+            strict_mode (str): Flag indicating if strict mode is enabled.
+
+        Returns:
+            str: The modified parsed object string.
+
+        Raises:
+            ProcessorError: If the element is not found and strict mode is enabled.
+        """
+        data = json.loads(parsed_object)
+
+        if element in data:
+            if isinstance(data[element], list):
+                if choice_value in data[element]:
+                    data[element].remove(choice_value)
+                    if not data[element]:
+                        del data[element]
+                elif strict_mode == "False":
+                    self.output(
+                        f"WARNING: choice_value '{choice_value}' not found in array '{element}', "
+                        f"parsed object unchanged."
+                    )
+                else:
+                    raise ProcessorError(
+                        f"choice_value '{choice_value}' not found in array '{element}'."
+                    )
+            elif data[element] == choice_value:
+                del data[element]
+            else:
+                raise ProcessorError(
+                    f"No matching key '{element}' with choice_value '{choice_value}' found in JSON."
+                )
+        else:
+            raise ProcessorError(f"Key '{element}' not found in JSON.")
+
+        return json.dumps(data, indent=4)
+
+    def execute(self):
+        """
+        Execute the main logic for adjusting pop-up choices in a Jamf Extension Attribute.
+        """
+        choice_operation = self.env.get("choice_operation")
+        parsed_object = self.env.get("parsed_object")
+        object_template = self.env.get("object_template")
+        output_dir = self.env.get("output_dir") or self.env.get("RECIPE_CACHE_DIR")
+        choice_value = self.env.get("choice_value")
+        strict_mode = self.env.get("strict_mode")
+
+        if object_template:
+            if not object_template.startswith("/"):
+                found_template = self.get_path_to_file(object_template)
+                if found_template:
+                    object_template = found_template
+                else:
+                    raise ProcessorError(f"File {object_template} not found")
+            try:
+                with open(object_template, "r", encoding="UTF-8") as file:
+                    parsed_object = file.read().strip()
+                    self.output(f"Read parsed_object from file: {object_template}")
+            except Exception as e:
+                raise ProcessorError(f"Error reading object_template file: {e}") from e
+
+        if strict_mode == "False":
+            self.output("WARNING: Strict mode disabled!")
+
+        is_json = parsed_object.strip().startswith("{") or parsed_object.strip().startswith("[")
+        self.validate_ea_type(is_json, parsed_object)
+
+        if object_template:
+            filename = os.path.basename(object_template)
+        else:
+            filename = self.generate_filename_from_object(is_json, parsed_object)
+
+        object_template = os.path.join(output_dir, filename)
+
+        if parsed_object.strip().startswith("<"):
+            element = "choice"
+            parent_xpath = "./input_type/popup_choices"
+            if choice_operation == "add":
+                parsed_object = self.add_xml_tag(
+                    parsed_object,
+                    parent_xpath,
+                    element,
+                    choice_value,
+                    strict_mode
+                )
+            elif choice_operation == "remove":
+                parsed_object = self.remove_xml_tag(
+                    parsed_object,
+                    element,
+                    choice_value,
+                    strict_mode
+                )
+        elif is_json:
+            element = "popupMenuChoices"
+            if choice_operation == "add":
+                parsed_object = self.add_json_key(
+                    parsed_object,
+                    element,
+                    choice_value,
+                    strict_mode
+                )
+            elif choice_operation == "remove":
+                parsed_object = self.remove_json_key(
+                    parsed_object,
+                    element,
+                    choice_value,
+                    strict_mode
+                )
+        else:
+            raise ProcessorError("Unsupported data format. Use XML or JSON.")
+
+        with open(object_template, "w", encoding="utf-8") as file:
+            file.write(parsed_object)
+
+        self.env["object_template"] = object_template
+        self.env["parsed_object"] = parsed_object

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -132,9 +132,10 @@ class JamfObjectReaderBase(JamfUploaderBase):
             payload_filetype = "sh"
             if object_type == "computer_extension_attribute":
                 payload = json.loads(parsed_object)["scriptContents"]
-                # determine the script type
-                if "python" in payload.partition("\n")[0]:
-                    payload_filetype = "py"
+                if payload is not None:
+                    # determine the script type
+                    if "python" in payload.partition("\n")[0]:
+                        payload_filetype = "py"
             elif object_type == "script":
                 payload = json.loads(parsed_object)["scriptContents"]
             elif (
@@ -151,7 +152,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
                 )
                 payload_filetype = "mobileconfig"
 
-            # dump the object to file is output_dir is specified
+            # dump the object to file if output_dir is specified
             if output_dir:
                 # construct the filename
                 if "JSSResource" in self.api_endpoints(object_type):

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -43,7 +43,7 @@ class JamfUploaderBase(Processor):
     """Common functions used by at least two JamfUploader processors."""
 
     # Global version
-    __version__ = "2025.2.17.0"
+    __version__ = "2025.3.5.0"
 
     def api_endpoints(self, object_type):
         """Return the endpoint URL from the object type"""

--- a/JamfUploaderProcessors/READMEs/JamfExtensionAttributePopupChoiceAdjuster.md
+++ b/JamfUploaderProcessors/READMEs/JamfExtensionAttributePopupChoiceAdjuster.md
@@ -1,0 +1,34 @@
+# JamfExtensionAttributePopupChoiceAdjuster
+
+## Description
+
+A processor for AutoPkg that adds or removes pop-up choices from a Jamf Pro Extension Attribute. It modifies XML or JSON files representing Jamf objects and can be used independently or as part of a larger workflow.
+
+## Input variables
+
+- **object_template**:
+  - **required**: False
+  - **description**: Full path of the object file to modify.
+- **parsed_object**:
+  - **required**: False
+  - **description**: XML or JSON parsed object string to modify. Used if `object_template` is not supplied, e.g., if taking input from `JamfObjectReader`.
+- **choice_operation**:
+  - **required**: True
+  - **description**: Specify `'add'` to add a choice or `'remove'` to remove a choice.
+- **choice_value**:
+  - **required**: True
+  - **description**: Pop-up choice value to add or remove.
+- **strict_mode**:
+  - **required**: False
+  - **description**: Raise a `ProcessorError` when adding a choice that already exists or removing a choice that does not exist in the parsed object. If set to `False`, continues without modifying the parsed object. This ensures no unintended changes are made to the Jamf API, but incorrect choice names may go unnoticed.
+  - **default**: `True`
+- **output_dir**:
+  - **required**: False
+  - **description**: Directory to save the modified XML or JSON file. Defaults to `RECIPE_CACHE_DIR`.
+
+## Output variables
+
+- **object_template**:
+  - **description**: Full path of the modified object file. Intended to pass to `JamfObjectUploader`.
+- **parsed_object**:
+  - **description**: Parsed processed object string. For chaining additional `JamfExtensionAttributePopupChoiceAdjuster` processors.

--- a/JamfUploaderProcessors/READMEs/JamfMobileDeviceExtensionAttributeUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMobileDeviceExtensionAttributeUploader.md
@@ -1,8 +1,8 @@
-# JamfExtensionAttributeUploader
+# JamfMobileDeviceExtensionAttributeUploader
 
 ## Description
 
-A processor for AutoPkg that will upload an Extension Attribute item to a Jamf Cloud or on-prem server.
+A processor for AutoPkg that will upload a Mobile Device Extension Attribute item to a Jamf Cloud or on-prem server.
 
 ## Input variables
 
@@ -23,42 +23,32 @@ A processor for AutoPkg that will upload an Extension Attribute item to a Jamf C
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
 - **ea_name**:
   - **required**: False
-  - **description**: Extension Attribute name
-- **ea_script_path**:
-  - **required**: False
-  - **description**: Full path to the script to be uploaded
+  - **description**: Mobile Device Extension Attribute name
 - **replace_ea**:
   - **required**: False
-  - **description**: Overwrite an existing Extension Attribute if True.
+  - **description**: Overwrite an existing Mobile Device Extension Attribute if True.
   - **default**: False
 - **ea_inventory_display:**
   - **required:** False
-  - **description:** Inventory Display value for the EA.
+  - **description:** Inventory Display value for the Mobile Device Extension Attribute.
   - **default:** "Extension Attributes"
 - **ea_data_type:**
   - **required:** False
-  - **description:** Data type for the EA. One of String, Integer or Date.
+  - **description:** Data type for the Mobile Device Extension Attribute. One of String, Integer or Date.
   - **default:** "String"
 - **ea_popup_choices:**
   - **required:** False
-  - **description:** Comma-separated list of popup choices for the EA.
+  - **description:** Comma-separated list of popup choices for the Mobile Device Extension Attribute.
 - **ea_input_type:**
   - **required:** False
-  - **description:** Type of EA. One of script, popup, text, or ldap.
+  - **description:** Type of Mobile Device Extension Attribute. One of popup, text, or ldap.
+  - **default:** "text"
 - **ea_description:**
   - **required:** False
-  - **description:** Description for the EA.
+  - **description:** Description for the Mobile Device Extension Attribute.
 - **ea_directory_service_attribute_mapping:**
   - **required:** False
   - **description:** Directory Service (LDAP) attribute mapping. Currently this must be manually set.
-- **ea_enabled:**
-  - **required:** False
-  - **description:** String-based EAs can be disabled.
-  - **default:** True
-- **skip_script_key_substitution**:
-  - **required**: False
-  - **description**: Skip substitution of keys marked between `%` signs in the script.
-  - **default**: False
 - **sleep:**
   - **required:** False
   - **description:** Pause after running this processor for specified seconds.
@@ -66,5 +56,5 @@ A processor for AutoPkg that will upload an Extension Attribute item to a Jamf C
 
 ## Output variables
 
-- **jamfextensionattributeuploader_summary_result:**
+- **jamfmobiledeviceextensionattributeuploader_summary_result:**
   - **description:** Description of interesting results.

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -61,6 +61,30 @@ elif [[ $test_type == "scope" ]]; then
         --not-strict \
         "$verbosity"
 
+elif [[ $test_type == "ea-popup-remove" ]]; then
+    # adjust a scope
+    "$DIR"/../jamf-upload.sh eapopup \
+        --prefs "$prefs" \
+        --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
+        --template "/Users/Shared/Jamf/JamfUploaderTests/jssimporter-computer_extension_attributes-Test Popup.json" \
+        --operation "remove" \
+        --value "1.3" \
+        --output "/Users/Shared/Jamf/JamfUploaderTests" \
+        --not-strict \
+        "$verbosity"
+
+elif [[ $test_type == "ea-popup-add" ]]; then
+    # adjust a scope
+    "$DIR"/../jamf-upload.sh eapopup \
+        --prefs "$prefs" \
+        --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
+        --template "/Users/Shared/Jamf/JamfUploaderTests/jssimporter-computer_extension_attributes-Test Popup.json" \
+        --operation "add" \
+        --value "1.3" \
+        --output "/Users/Shared/Jamf/JamfUploaderTests" \
+        --not-strict \
+        "$verbosity"
+
 
 # example object types (Classic API)
 # computer_group
@@ -164,6 +188,17 @@ elif [[ $test_type == "read-ea" ]]; then
         --name "AdobeFlashVersion" \
         --output "/Users/Shared/Jamf/JamfUploaderTests" \
         "$verbosity"
+
+elif [[ $test_type == "read-ea-popup" ]]; then
+    # read a generic Classic API object
+    "$DIR"/../jamf-upload.sh read \
+        --prefs "$prefs" \
+        --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
+        --type "computer_extension_attribute" \
+        --name "Test Popup" \
+        --output "/Users/Shared/Jamf/JamfUploaderTests" \
+        "$verbosity"
+
 
 elif [[ $test_type == "read-eas" ]]; then
     # read a generic Classic API object

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -361,6 +361,20 @@ elif [[ $test_type == "ea" ]]; then
         "$verbosity" \
         --replace
 
+elif [[ $test_type == "ea-popup" ]]; then
+    # upload an extension attribute
+    "$DIR"/../jamf-upload.sh ea \
+        --prefs "$prefs" \
+        --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
+        --name "Test Popup" \
+        --type "popup" \
+        --choices "1.0,1.1,1.2,1.3" \
+        --description "Choose a version" \
+        --inventory-display "General" \
+        --disabled \
+        "$verbosity" \
+        --replace
+
 elif [[ $test_type == "macapp" ]]; then
     # upload a mac app
     "$DIR"/../jamf-upload.sh macapp \

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -406,7 +406,19 @@ elif [[ $test_type == "ea-popup" ]]; then
         --choices "1.0,1.1,1.2,1.3" \
         --description "Choose a version" \
         --inventory-display "General" \
-        --disabled \
+        "$verbosity" \
+        --replace
+
+elif [[ $test_type == "mea-popup" ]]; then
+    # upload an extension attribute
+    "$DIR"/../jamf-upload.sh mobiledeviceea \
+        --prefs "$prefs" \
+        --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
+        --name "Test Popup" \
+        --type "popup" \
+        --choices "1.0,1.1,1.2,1.3" \
+        --description "Choose a version" \
+        --inventory-display "General" \
         "$verbosity" \
         --replace
 

--- a/jamf-upload.sh
+++ b/jamf-upload.sh
@@ -145,6 +145,22 @@ Mobile Device App Upload arguments:
     --key X=Y               Substitutable values in the template and AppConfig. Multiple values can be supplied
     --replace               Replace existing item
 
+Mobile Device Extension Attribute Upload arguments:
+    --name <string>         The name
+    --type <string>         The input type, either 'text', 'popup', 
+                            or 'ldap' (default is 'script')
+    --data-type <string>    The data type, either 'string', 'integer', or 'date'. 
+                            Only used for 'text' and 'popup' input types. Default is 'string'.
+    --description <string>  The description
+    --ldap-mapping <string> The Directory Service Attribute Mapping. Musst be a valid mapping.
+    --choices               Comma-separated list of values for 'popup' input type. 
+                            Must be a comma-separated list.
+    --inventory-display <string>
+                            The inventory display type. One of GENERAL, HARDWARE, OPERATING_SYSTEM, 
+                            USER_AND_LOCATION, PURCHASING, EXTENSION_ATTRIBUTES.
+    --key X=Y               Substitutable values in the template. Multiple values can be supplied
+    --replace               Replace existing item
+
 Mobile Device Group Upload arguments:
     --name <string>         The name
     --template <path>       XML template
@@ -402,6 +418,8 @@ elif [[ $object == "macapp" ]]; then
     processor="JamfMacAppUploader"
 elif [[ $object == "mobiledeviceapp" ]]; then
     processor="JamfMobileDeviceAppUploader"
+elif [[ $object == "mobiledeviceea" || $object == "mobiledeviceextensionattribute" ]]; then
+    processor="JamfMobileDeviceExtensionAttributeUploader"
 elif [[ $object == "mobiledevicegroup" ]]; then
     processor="JamfMobileDeviceGroupUploader"
 elif [[ $object == "mobiledeviceprofile" ]]; then
@@ -510,7 +528,7 @@ while test $# -gt 0 ; do
                 if plutil -replace dock_item_type -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote dock_item_type='$1' into $temp_processor_plist"
                 fi
-            elif [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+            elif [[ $processor == "JamfExtensionAttributeUploader" || $processor == "JamfMobileDeviceExtensionAttributeUploader" ]]; then
                 if plutil -replace ea_input_type -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote ea_input_type='$1' into $temp_processor_plist"
                 fi
@@ -572,7 +590,7 @@ while test $# -gt 0 ; do
                 if plutil -replace replace_dock_item -string "True" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote replace_dock_item='True' into $temp_processor_plist"
                 fi
-            elif [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+            elif [[ $processor == "JamfExtensionAttributeUploader" || $processor == "JamfMobileDeviceExtensionAttributeUploader" ]]; then
                 if plutil -replace replace_ea -string "True" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote replace_ea='True' into $temp_processor_plist"
                 fi
@@ -632,7 +650,7 @@ while test $# -gt 0 ; do
                 if plutil -replace dock_item_name -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote dock_item_name='$1' into $temp_processor_plist"
                 fi
-            elif [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+            elif [[ $processor == "JamfExtensionAttributeUploader" || $processor == "JamfMobileDeviceExtensionAttributeUploader" ]]; then
                 if plutil -replace ea_name -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote ea_name='$1' into $temp_processor_plist"
                 fi
@@ -827,7 +845,7 @@ while test $# -gt 0 ; do
                 if plutil -replace profile_description -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote profile_description='$1' into $temp_processor_plist"
                 fi
-            elif [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+            elif [[ $processor == "JamfExtensionAttributeUploader" || $processor == "JamfMobileDeviceExtensionAttributeUploader" ]]; then
                 if plutil -replace ea_description -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote ea_description='$1' into $temp_processor_plist"
                 fi
@@ -908,7 +926,7 @@ while test $# -gt 0 ; do
             ;;
         --data-type)
             shift
-            if [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+            if [[ $processor == "JamfExtensionAttributeUploader" || $processor == "JamfMobileDeviceExtensionAttributeUploader" ]]; then
                 if plutil -replace ea_data_type -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote ea_data_type='$1' into $temp_processor_plist"
                 fi
@@ -916,7 +934,7 @@ while test $# -gt 0 ; do
             ;;
         --inventory-display)
             shift
-            if [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+            if [[ $processor == "JamfExtensionAttributeUploader" || $processor == "JamfMobileDeviceExtensionAttributeUploader" ]]; then
                 if plutil -replace ea_inventory_display -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote ea_inventory_display='$1' into $temp_processor_plist"
                 fi
@@ -924,7 +942,7 @@ while test $# -gt 0 ; do
             ;;
         --ldap-mapping)
             shift
-            if [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+            if [[ $processor == "JamfExtensionAttributeUploader" || $processor == "JamfMobileDeviceExtensionAttributeUploader" ]]; then
                 if plutil -replace ea_directory_service_attribute_mapping -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote ea_directory_service_attribute_mapping='$1' into $temp_processor_plist"
                 fi
@@ -932,7 +950,7 @@ while test $# -gt 0 ; do
             ;;
         --choices)
             shift
-            if [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+            if [[ $processor == "JamfExtensionAttributeUploader" || $processor == "JamfMobileDeviceExtensionAttributeUploader" ]]; then
                 if plutil -replace ea_popup_choices -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote ea_popup_choices='$1' into $temp_processor_plist"
                 fi

--- a/jamf-upload.sh
+++ b/jamf-upload.sh
@@ -24,6 +24,7 @@ Valid object types:
     profile | computerprofile
     mobiledeviceprofile
     ea | extensionattribute | computerextensionattribute
+    eapopup | eapopupadjuster
     icon
     ldap_server
     logflush

--- a/jamf-upload.sh
+++ b/jamf-upload.sh
@@ -23,7 +23,7 @@ Valid object types:
     mobiledevicegroup
     profile | computerprofile
     mobiledeviceprofile
-    ea | extensionattribute
+    ea | extensionattribute | computerextensionattribute
     icon
     ldap_server
     logflush
@@ -93,9 +93,21 @@ Dock Item Upload arguments:
     --path <string>         Path of Dock Item - e.g. 'file:///Applications/Safari.app/'
     --replace               Replace existing item
 
-Extension Attribute Upload arguments:
+Computer Extension Attribute Upload arguments:
     --name <string>         The name
+    --type <string>         The input type, either 'script', 'text', 'popup', 
+                            or 'ldap' (default is 'script')
+    --data-type <string>    The data type, either 'string', 'integer', or 'date'. 
+                            Only used for 'text' and 'popup' input types. Default is 'string'.
+    --description <string>  The description
+    --disabled              Disable the EA
     --script <path>         Full path of the script to be uploaded
+    --ldap-mapping <string> The Directory Service Attribute Mapping. Musst be a valid mapping.
+    --choices               Comma-separated list of values for 'popup' input type. 
+                            Must be a comma-separated list.
+    --inventory-display <string>
+                            The inventory display type. One of GENERAL, HARDWARE, OPERATING_SYSTEM, 
+                            USER_AND_LOCATION, PURCHASING, EXTENSION_ATTRIBUTES.
     --key X=Y               Substitutable values in the template. Multiple values can be supplied
     --replace               Replace existing item
 
@@ -258,6 +270,14 @@ Policy Delete arguments:
 
 MISCELLANEOUS ACTIONS OPTIONS
 
+Extension Attribute Popup Choice Adjuster arguments:
+    --template <path>       XML template
+    --operation <string>    The operation to perform, either 'add' or 'remove'
+    --value <string>        The value to add or remove
+    --not-strict            Don't fail if adding a choice value that already exists 
+                            or removing a choice value that does not exist in the raw object
+    --output <dir>          Optional directory to output the parsed XML to. Directory must exist.
+
 Package Clean arguments:
     --name <string>         The name to match
     --smb-url <url>         URL of the fileshare distribution point (on premises Jamf Pro only)
@@ -369,8 +389,10 @@ elif [[ $object == "profile" || $object == "computerprofile" ]]; then
     processor="JamfComputerProfileUploader"
 elif [[ $object == "dock" || $object == "dockitem" ]]; then
     processor="JamfDockItemUploader"
-elif [[ $object == "ea" || $object == "extensionattribute" ]]; then
+elif [[ $object == "ea" || $object == "extensionattribute" || $object == "computerextensionattribute" ]]; then
     processor="JamfExtensionAttributeUploader"
+elif [[ $object == "eapopup" || $object == "eapopupadjuster" ]]; then
+    processor="JamfExtensionAttributePopupChoiceAdjuster"
 elif [[ $object == "icon" ]]; then
     processor="JamfIconUploader"
 elif [[ $object == "ldap_server" ]]; then
@@ -486,6 +508,10 @@ while test $# -gt 0 ; do
             elif [[ $processor == "JamfDockItemUploader" ]]; then
                 if plutil -replace dock_item_type -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote dock_item_type='$1' into $temp_processor_plist"
+                fi
+            elif [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+                if plutil -replace ea_input_type -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote ea_input_type='$1' into $temp_processor_plist"
                 fi
             elif [[ $processor == "JamfObjectReader" || $processor == "JamfObjectDeleter" || $processor == "JamfObjectUploader" ]]; then
                 # override for generic items, as this key is written later, normally providing the value of $object
@@ -677,6 +703,10 @@ while test $# -gt 0 ; do
                 if plutil -replace profile_template -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote profile_template='$1' into $temp_processor_plist"
                 fi
+            elif [[ $processor == "JamfExtensionAttributePopupChoiceAdjuster" ]]; then
+                if plutil -replace object_template -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote object_template='$1' into $temp_processor_plist"
+                fi
             elif [[ $processor == "JamfMacAppUploader" ]]; then
                 if plutil -replace macapp_template -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote macapp_template='$1' into $temp_processor_plist"
@@ -796,6 +826,10 @@ while test $# -gt 0 ; do
                 if plutil -replace profile_description -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote profile_description='$1' into $temp_processor_plist"
                 fi
+            elif [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+                if plutil -replace ea_description -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote ea_description='$1' into $temp_processor_plist"
+                fi
             fi
             ;;
         --computergroup)
@@ -823,9 +857,87 @@ while test $# -gt 0 ; do
                 if plutil -replace dock_item_path -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote dock_item_path='$1' into $temp_processor_plist"
                 fi
+            elif [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+                if plutil -replace ea_script_path -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote ea_script_path='$1' into $temp_processor_plist"
+                fi
             fi
             ;;
-        --script|--script_path)
+        --not-strict) 
+            if [[ $processor == "JamfExtensionAttributePopupChoiceAdjuster" || $processor == "JamfScopeAdjuster" ]]; then
+                if plutil -replace strict_mode -string "False" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote strict_mode='False' into $temp_processor_plist"
+                fi
+            fi
+            ;;
+        --operation)
+            shift
+            if [[ $processor == "JamfExtensionAttributePopupChoiceAdjuster" ]]; then
+                if plutil -replace choice_operation -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote choice_operation='$1' into $temp_processor_plist"
+                fi
+            elif [[ $processor == "JamfScopeAdjuster" ]]; then
+                if plutil -replace scoping_operation -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote scoping_operation='$1' into $temp_processor_plist"
+                fi
+            fi
+            ;;
+        --output)
+            shift
+            if [[ $processor == "JamfExtensionAttributePopupChoiceAdjuster" || $processor == "JamfObjectReader" || $processor == "JamfScopeAdjuster" ]]; then
+                if plutil -replace output_dir -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote output_dir='$1' into $temp_processor_plist"
+                fi
+            fi
+            ;;
+        --value)
+            shift
+            if [[ $processor == "JamfExtensionAttributePopupChoiceAdjuster" ]]; then
+                if plutil -replace choice_value -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote choice_value='$1' into $temp_processor_plist"
+                fi
+            fi
+            ;;
+        --disabled)
+            if [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+                if plutil -replace ea_enabled -string "False" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote ea_enabled='False' into $temp_processor_plist"
+                fi
+            fi
+            ;;
+        --data-type)
+            shift
+            if [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+                if plutil -replace ea_data_type -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote ea_data_type='$1' into $temp_processor_plist"
+                fi
+            fi
+            ;;
+        --inventory-display)
+            shift
+            if [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+                if plutil -replace ea_inventory_display -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote ea_inventory_display='$1' into $temp_processor_plist"
+                fi
+            fi
+            ;;
+        --ldap-mapping)
+            shift
+            if [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+                if plutil -replace ea_directory_service_attribute_mapping -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote ea_directory_service_attribute_mapping='$1' into $temp_processor_plist"
+                fi
+            fi
+            ;;
+        --choices)
+            shift
+            if [[ $processor == "JamfExtensionAttributeUploader" ]]; then
+                if plutil -replace ea_popup_choices -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote ea_popup_choices='$1' into $temp_processor_plist"
+                fi
+            fi
+            ;;
+        --script|--script-path)
             shift
             if [[ $processor == "JamfExtensionAttributeUploader" ]]; then
                 if plutil -replace ea_script_path -string "$1" "$temp_processor_plist"; then
@@ -893,18 +1005,6 @@ while test $# -gt 0 ; do
             if [[ $processor == "JamfObjectReader" ]]; then
                 if plutil -replace all_objects -string "True" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote all_objects='True' into $temp_processor_plist"
-                fi
-            fi
-            ;;
-        --output)
-            shift
-            if [[ $processor == "JamfObjectReader" ]]; then
-                if plutil -replace output_dir -string "$1" "$temp_processor_plist"; then
-                    echo "   [jamf-upload] Wrote output_dir='$1' into $temp_processor_plist"
-                fi
-            elif [[ $processor == "JamfScopeAdjuster" ]]; then
-                if plutil -replace output_dir -string "$1" "$temp_processor_plist"; then
-                    echo "   [jamf-upload] Wrote output_dir='$1' into $temp_processor_plist"
                 fi
             fi
             ;;
@@ -1124,25 +1224,10 @@ while test $# -gt 0 ; do
                 fi
             fi
             ;;
-        --not-strict) 
-            if [[ $processor == "JamfScopeAdjuster" ]]; then
-                if plutil -replace strict_mode -string "False" "$temp_processor_plist"; then
-                    echo "   [jamf-upload] Wrote strict_mode='False' into $temp_processor_plist"
-                fi
-            fi
-            ;;
         --not-stripped) 
             if [[ $processor == "JamfScopeAdjuster" ]]; then
                 if plutil -replace strip_raw_xml -string "False" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote strip_raw_xml='False' into $temp_processor_plist"
-                fi
-            fi
-            ;;
-        --operation)
-            shift
-            if [[ $processor == "JamfScopeAdjuster" ]]; then
-                if plutil -replace scoping_operation -string "$1" "$temp_processor_plist"; then
-                    echo "   [jamf-upload] Wrote scoping_operation='$1' into $temp_processor_plist"
                 fi
             fi
             ;;


### PR DESCRIPTION
Contains new `JamfExtensionAttributePopupChoiceAdjuster` and `JamfMobileDeviceExtensionAttributeUploder` processors.

Additionally, `JamfExtensionAttributeUploader` can now handle different input types, including popup choices, that are provided with a comma-separated list.