### PR TITLE
Enhancements to JamfScopeAdjuster

### DIFF
--- a/JamfUploaderProcessors/JamfScopeAdjuster.py
+++ b/JamfUploaderProcessors/JamfScopeAdjuster.py
@@ -67,7 +67,7 @@ class JamfScopeAdjuster(JamfScopeAdjusterBase):
             "required": True,
             "description": (
                 "Type of scopeable object. Specify 'user_group', 'computer_group' "
-                "'mobile_device_group'."
+                "'mobile_device_group', 'network_segment', 'building', 'department'."
             ),
         },
         "scopeable_name": {

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfScopeAdjusterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfScopeAdjusterBase.py
@@ -120,17 +120,27 @@ class JamfScopeAdjusterBase(JamfUploaderBase):
             parent.append(new_tag)
 
         else:
-            if scoping_type == "target" and scopeable_type == (
-                "computer_group" or "mobile_device_group"
-                or "building" or "department"
+            if scoping_type == "target" and scopeable_type in (
+                "computer_group", "mobile_device_group",
+                "building", "department"
                 ):
                 parent_xpath = f"./scope/{scopeable_type}s"
                 if scope.find(f"{scopeable_type}s") is None:
                     ET.SubElement(scope, f"{scopeable_type}s")
 
             elif (
-                object_type != "restricted_software" and scoping_type == "limitation"
-                ) or scoping_type == "exclusion":
+                object_type != "restricted_software" and scoping_type ==
+                "limitation" and scopeable_type in
+                ("network_segment", "user_group", "computer_group")
+                ) or (
+                object_type == "restricted_software" and scoping_type == "exclusion"
+                and scopeable_type in ("computer_group", "building", "department")
+                ) or (
+                object_type != "restricted_software" and scoping_type == "exclusion"
+                and scopeable_type in
+                ("computer_group", "mobile_device_group", "user_group",
+                "network_segment", "building", "department")
+                ):
                 parent_xpath = f"./scope/{scoping_type}s/{scopeable_type}s"
                 scoping_types = scope.find(f"{scoping_type}s")
                 if scoping_types is None:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfScopeAdjusterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfScopeAdjusterBase.py
@@ -120,12 +120,17 @@ class JamfScopeAdjusterBase(JamfUploaderBase):
             parent.append(new_tag)
 
         else:
-            if scoping_type == "target":
+            if scoping_type == "target" and scopeable_type == (
+                "computer_group" or "mobile_device_group"
+                or "building" or "department"
+                ):
                 parent_xpath = f"./scope/{scopeable_type}s"
                 if scope.find(f"{scopeable_type}s") is None:
                     ET.SubElement(scope, f"{scopeable_type}s")
 
-            elif scoping_type == "limitation" or scoping_type == "exclusion":
+            elif (
+                object_type != "restricted_software" and scoping_type == "limitation"
+                ) or scoping_type == "exclusion":
                 parent_xpath = f"./scope/{scoping_type}s/{scopeable_type}s"
                 scoping_types = scope.find(f"{scoping_type}s")
                 if scoping_types is None:
@@ -136,7 +141,9 @@ class JamfScopeAdjusterBase(JamfUploaderBase):
 
             else:
                 raise ProcessorError(
-                    f"Incorrect scoping_type '{scoping_type}' specified."
+                    "Unsupported scope: "
+                    f"Object type: {object_type} , Scoping type: "
+                    f"{scoping_type} , Scopeable type: {scopeable_type} , "
                 )
 
             parent = root.find(parent_xpath)

--- a/JamfUploaderProcessors/READMEs/JamfScopeAdjuster.md
+++ b/JamfUploaderProcessors/READMEs/JamfScopeAdjuster.md
@@ -20,7 +20,7 @@ A processor for AutoPkg that adds or removes a scopeable object (target, limitat
   - **description:** Type of scope. Specify `target`, `limitation`, or `exclusion`.
 - **scopeable_type:**  
   - **required:** True  
-  - **description:** Type of scopeable object. Specify `user_group`, `computer_group`, or `mobile_device_group`.
+  - **description:** Type of scopeable object. Specify `user_group`, `computer_group`, `mobile_device_group`, `network_segment`, `building`, or `department`.
 - **scopeable_name:**  
   - **required:** True  
   - **description:** Name of the scopable object.


### PR DESCRIPTION
Tested and verified support for targeting and excluding:

* Network Segments
* Buildings
* Departments

Also added validation to ensure we only target, limited and exclude valid scopeable types. This is especially important for Restricted Software as it supports a narrower subset, with strange GUI behaviour observed if limitations are added via the API (this should not be allowed if attempted - we do get the correct 409 response but the limitations show in the Scope column under the Restricted Software page table!).