### PR TITLE
Store API account credentials in macOS keychain

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAPIClientUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAPIClientUploaderBase.py
@@ -166,10 +166,10 @@ class JamfAPIClientUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # now start the process of uploading the object
         # check for existing object

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAPIRoleUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAPIRoleUploaderBase.py
@@ -127,10 +127,10 @@ class JamfAPIRoleUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # Check for existing item
         self.output(f"Checking for existing '{object_name}' on {jamf_url}")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
@@ -174,11 +174,10 @@ class JamfAccountUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
-
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
         # check for existing account - requires obj_name and account type
         obj_id = self.get_account_id_from_name(
             jamf_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfCategoryUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfCategoryUploaderBase.py
@@ -102,10 +102,10 @@ class JamfCategoryUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # now process the category
         # check for existing category

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfClassicAPIObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfClassicAPIObjectUploaderBase.py
@@ -127,10 +127,10 @@ class JamfClassicAPIObjectUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # Check for existing item
         self.output(f"Checking for existing '{object_name}' on {jamf_url}")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupDeleterBase.py
@@ -89,10 +89,10 @@ class JamfComputerGroupDeleterBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # check for existing - requires obj_name
         obj_type = "computer_group"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupUploaderBase.py
@@ -157,10 +157,10 @@ class JamfComputerGroupUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # check for existing - requires obj_name
         obj_type = "computer_group"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
@@ -424,10 +424,10 @@ class JamfComputerProfileUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         obj_type = "os_x_configuration_profile"
         obj_name = mobileconfig_name

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfDockItemUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfDockItemUploaderBase.py
@@ -123,10 +123,10 @@ class JamfDockItemUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # Check for existing dock item
         self.output(f"Checking for existing '{dock_item_name}' on {jamf_url}")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
@@ -195,11 +195,10 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
-
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
         # check for existing - requires obj_name
         obj_type = "computer_extension_attribute"
         obj_name = ea_name

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfIconUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfIconUploaderBase.py
@@ -123,10 +123,10 @@ class JamfIconUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # obtain the icon from the URI if no file path provided
         if "https://ics.services.jamfcloud.com/icon" in icon_uri and not icon_file:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
@@ -155,10 +155,10 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # check for existing - requires obj_name
         obj_type = "mac_application"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceAppUploaderBase.py
@@ -187,10 +187,10 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # check for existing - requires obj_name
         obj_type = "mobile_device_application"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceExtensionAttributeUploaderBase.py
@@ -166,10 +166,10 @@ class JamfMobileDeviceExtensionAttributeUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # check for existing - requires obj_name
         obj_type = "mobile_device_extension_attribute"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceGroupUploaderBase.py
@@ -138,10 +138,10 @@ class JamfMobileDeviceGroupUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # check for existing - requires obj_name
         obj_type = "mobile_device_group"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
@@ -301,10 +301,10 @@ class JamfMobileDeviceProfileUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         obj_type = "configuration_profile"
         obj_name = mobileconfig_name

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectDeleterBase.py
@@ -91,10 +91,10 @@ class JamfObjectDeleterBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # check for existing - requires obj_name
         obj_id = self.get_api_obj_id_from_name(

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -62,18 +62,18 @@ class JamfObjectReaderBase(JamfUploaderBase):
             list_only = False
 
         # clear any pre-existing summary result
-        if "jamfclassicapiobjectreader_summary_result" in self.env:
-            del self.env["jamfclassicapiobjectreader_summary_result"]
+        if "jamfobjectreader_summary_result" in self.env:
+            del self.env["jamfobjectreader_summary_result"]
 
         # now start the process of reading the object
 
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # get instance name from URL
         host = jamf_url.partition("://")[2]

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
@@ -157,11 +157,10 @@ class JamfObjectUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
-
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
         # check for an existing object except for settings-related endpoints
         if "_settings" not in object_type:
             self.output(f"Checking for existing '{object_name}' on {jamf_url}")
@@ -215,7 +214,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
         self.env["object_type"] = object_type
         self.env["object_updated"] = object_updated
         if object_updated:
-            self.env["jamfclassicapiobjectuploader_summary_result"] = {
+            self.env["jamfobjectuploader_summary_result"] = {
                 "summary_text": "The following objects were updated in Jamf Pro:",
                 "report_fields": ["object_name", "object_type", "template"],
                 "data": {

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
@@ -191,10 +191,10 @@ class JamfPackageCleanerBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # check for existing
         obj_type = "package"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageRecalculatorBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageRecalculatorBase.py
@@ -88,10 +88,10 @@ class JamfPackageRecalculatorBase(JamfUploaderBase):
         # Version 11.5+ will use the v1/packages endpoint
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Valid credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         jamf_pro_version = self.get_jamf_pro_version(jamf_url, token)
         if APLooseVersion(jamf_pro_version) >= APLooseVersion("11.5"):

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
@@ -994,13 +994,10 @@ class JamfPackageUploaderBase(JamfUploaderBase):
         # (dbfileupload requires basic auth)
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError(
-                "ERROR: Valid credentials not supplied (note that API Clients cannot "
-                "be used on Jamf Pro versions older than 11.5)"
-            )
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # get Jamf Pro version to determine default mode
         # Version 11.5+ will use the v1/packages endpoint

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPatchCheckerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPatchCheckerBase.py
@@ -130,10 +130,10 @@ class JamfPatchCheckerBase(JamfUploaderBase):
         # Get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # Patch Softwaretitle
         obj_type = "patch_software_title"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
@@ -286,10 +286,10 @@ class JamfPatchUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # Patch Icon:
         # Sadly there is currently no (reasonable) way to upload an icon for a patch policy.

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPkgMetadataUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPkgMetadataUploaderBase.py
@@ -248,10 +248,10 @@ class JamfPkgMetadataUploaderBase(JamfUploaderBase):
         # Version 11.5+ will use the v1/packages endpoint
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Valid credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         jamf_pro_version = self.get_jamf_pro_version(jamf_url, token)
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyDeleterBase.py
@@ -83,10 +83,10 @@ class JamfPolicyDeleterBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # check for existing - requires obj_name
         obj_type = "policy"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyLogFlusherBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyLogFlusherBase.py
@@ -95,10 +95,10 @@ class JamfPolicyLogFlusherBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # check for existing - requires obj_name
         obj_type = "policy"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
@@ -243,10 +243,10 @@ class JamfPolicyUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # check for existing - requires obj_name
         obj_type = "policy"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
@@ -181,10 +181,10 @@ class JamfScriptUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         # get the id for a category if supplied
         if script_category:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
@@ -189,10 +189,10 @@ class JamfSoftwareRestrictionUploaderBase(JamfUploaderBase):
         # get token using oauth or basic auth depending on the credentials given
         if jamf_url and client_id and client_secret:
             token = self.handle_oauth(jamf_url, client_id, client_secret)
-        elif jamf_url and jamf_user and jamf_password:
+        elif jamf_url:
             token = self.handle_api_auth(jamf_url, jamf_user, jamf_password)
         else:
-            raise ProcessorError("ERROR: Credentials not supplied")
+            raise ProcessorError("ERROR: Jamf Pro URL not supplied")
 
         obj_type = "restricted_software"
         obj_name = restriction_name

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -51,7 +51,7 @@ fi
 case "$test_type" in
     list-policies)
         "$DIR"/../jamf-upload.sh read \
-            --prefs "$prefs" \
+            --prefs "$prefs_alt" \
             --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
             --type "policy" \
             --list \
@@ -204,7 +204,7 @@ case "$test_type" in
         ;;
     read-profiles)
         "$DIR"/../jamf-upload.sh read \
-            --prefs "$prefs" \
+            --prefs "$prefs_alt" \
             --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
             --type "os_x_configuration_profile" \
             --all \

--- a/set-credentials.sh
+++ b/set-credentials.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+: <<DOC
+Script to add the required credentials into your login keychain to allow repeated use.
+
+1. Ask for the instance list, show list, ask to apply to one, multiple or all
+2. Ask for the username (show any existing value of first instance in list as default)
+3. Ask for the password (show the associated user if already existing)
+4. Loop through each selected instance, check for an existing keychain entry, create or overwrite
+5. Check the credentials are working using the API
+DOC
+
+# functions
+verify_credentials() {
+    local jss_url="$1"
+    if [[ $verbose -gt 0 ]]; then
+        echo "Verifying credentials for $jss_url"
+    fi
+
+    # check for username entry in login keychain
+    # jss_api_user=$("${this_script_dir}/keychain.sh" -t internet -u -s "$jss_url")
+    jss_api_user=$(/usr/bin/security find-internet-password -s "$jss_url" -g 2>/dev/null | /usr/bin/grep "acct" | /usr/bin/cut -d \" -f 4 )
+
+    if [[ ! $jss_api_user ]]; then
+        echo "No keychain entry for $jss_url found. Please run the set_credentials.sh script to add the user to your keychain"
+        exit 1
+    fi
+
+    # check for password entry in login keychain
+    # jss_api_password=$("${this_script_dir}/keychain.sh" -t internet -p -s "$jss_url")
+    jss_api_password=$(/usr/bin/security find-internet-password -s "$jss_url" -a "$jss_api_user" -w -g 2>&1 )
+
+    if [[ ! $jss_api_password ]]; then
+        echo "No password for $jss_api_user found. Please run the set_credentials.sh script to add the password to your keychain"
+        exit 1
+    fi
+
+    # echo "$jss_api_user:$jss_api_password"  # UNCOMMENT-TO-DEBUG
+
+    # get a bearer token
+    output_location="/tmp/jamf_pro_credentials_verification"
+    mkdir -p "$output_location"
+    output_file_token="$output_location/output_token.txt"
+    output_file_record="$output_location/output_record.txt"
+
+    http_response=$(
+        curl --request POST \
+        --silent \
+        --user "$jss_api_user:$jss_api_password" \
+        --url "$jss_url/api/v1/auth/token" \
+        --write-out "%{http_code}" \
+        --header 'Accept: application/json' \
+        --output "$output_file_token"
+    )
+    echo "Token request HTTP response: $http_response"
+
+    token=$(plutil -extract token raw "$output_file_token")
+
+    # check Jamf Pro version
+    http_response=$(
+        curl --request GET \
+            --silent \
+            --header "authorization: Bearer $token" \
+            --header 'Accept: application/json' \
+            "$jss_url/api/v1/jamf-pro-version" \
+            --write-out "%{http_code}" \
+            --output "$output_file_record"
+    )
+    echo "Version request HTTP response: $http_response"
+}
+
+echo
+
+# ------------------------------------------------------------------------------------
+# 1. Ask for the instance
+# ------------------------------------------------------------------------------------
+
+echo "Enter Jamf Pro URL"
+read -r -p "URL : " inputted_url
+if [[ ! $inputted_url ]]; then
+    echo "No username supplied"
+    exit 1
+fi
+if [[ "$inputted_url" != "https://"* ]]; then
+    inputted_url="https://$inputted_url"
+fi
+
+# ------------------------------------------------------------------------------------
+# 2. Ask for the username (show any existing value of first instance in list as default)
+# ------------------------------------------------------------------------------------
+
+echo "Enter username for ${inputted_url}"
+read -r -p "User : " inputted_username
+if [[ ! $inputted_username ]]; then
+    echo "No username supplied"
+    exit 1
+fi
+
+# check for existing service entry in login keychain
+instance_base="${inputted_url/*:\/\//}"
+kc_check=$(security find-internet-password -s "${inputted_url}" -l "$instance_base ($inputted_username)" -a "$inputted_username" -g 2>/dev/null)
+
+if [[ $kc_check ]]; then
+    echo "Keychain entry for $inputted_username found on $instance_base"
+else
+    echo "Keychain entry for $inputted_username not found on $instance_base"
+fi
+
+echo
+# check for existing password entry in login keychain
+instance_pass=$(security find-internet-password -s "${inputted_url}" -l "$instance_base ($inputted_username)" -a "$inputted_username" -w -g 2>&1)
+
+if [[ $instance_pass ]]; then
+    echo "Password for $inputted_username found on $instance_base"
+else
+    echo "Password for $inputted_username not found on $instance_base"
+fi
+
+echo "Enter password for $inputted_username on $instance_base"
+[[ $instance_pass ]] && echo "(or press ENTER to use existing password from keychain for $inputted_username)"
+read -r -s -p "Pass : " inputted_password
+if [[ "$inputted_password" ]]; then
+    instance_pass="$inputted_password"
+elif [[ ! $instance_pass ]]; then
+    echo "No password supplied"
+    exit 1
+fi
+
+# ------------------------------------------------------------------------------------
+# 3. Loop through each selected instance
+# ------------------------------------------------------------------------------------
+echo
+echo
+security add-internet-password -U -s "$inputted_url" -l "$instance_base ($inputted_username)" -a "$inputted_username" -w "$instance_pass"
+echo "Credentials for $instance_base (user $inputted_username) added to keychain"
+
+# ------------------------------------------------------------------------------------
+# 4. Verify the credentials
+# ------------------------------------------------------------------------------------
+
+echo
+echo "Verifying credentials for $instance_base (user $inputted_username)"
+verify_credentials "$inputted_url"
+# print out version
+version=$(plutil -extract version raw "$output_file_record")
+if [[ $version ]]; then
+    echo "Connection successful. Jamf Pro version: $version"
+fi
+
+echo
+echo "Script complete"
+echo


### PR DESCRIPTION
This allows the Jamf Pro credentials to be stored in the keychain, which is more secure than storing the credentials in plain text in the AutoPkg preferences. 

This is currently limited to storing a Jamf Pro account - not API client IDs.

Use the `set-credentials.sh` script to add the credentials for a Jamf Pro URL to the keychain. You may continue to supply the `JSS_URL` key in the AutoPkg preferences, or provide it from the command line. The processor will look for a keychain entry matching the URL and attempt to extract the username and password.