### PR TITLE
Allow JamfObjectReader and JamfObjectUploader to function based on inputted ID rather than name

### DIFF
--- a/JamfUploaderProcessors/JamfObjectReader.py
+++ b/JamfUploaderProcessors/JamfObjectReader.py
@@ -83,6 +83,11 @@ class JamfObjectReader(JamfObjectReaderBase):
                 "the com.github.autopkg preference file."
             ),
         },
+        "object_id": {
+            "required": False,
+            "description": "ID of an object. May be used instead of supplying an object name.",
+            "default": "",
+        },
         "object_name": {
             "required": False,
             "description": "Name of the object. Required unless using 'all_objects'",

--- a/JamfUploaderProcessors/JamfObjectUploader.py
+++ b/JamfUploaderProcessors/JamfObjectUploader.py
@@ -79,6 +79,10 @@ class JamfObjectUploader(JamfObjectUploaderBase):
         "object_name": {
             "required": False,
             "description": "Name of the object. Required except for settings-related objects.",
+        },
+        "id": {
+            "required": False,
+            "description": "ID of an object. May be iused instead of supplying an object name.",
             "default": "",
         },
         "object_template": {

--- a/JamfUploaderProcessors/JamfObjectUploader.py
+++ b/JamfUploaderProcessors/JamfObjectUploader.py
@@ -80,9 +80,9 @@ class JamfObjectUploader(JamfObjectUploaderBase):
             "required": False,
             "description": "Name of the object. Required except for settings-related objects.",
         },
-        "id": {
+        "object_id": {
             "required": False,
-            "description": "ID of an object. May be iused instead of supplying an object name.",
+            "description": "ID of an object. May be used instead of supplying an object name.",
             "default": "",
         },
         "object_template": {

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
@@ -88,8 +88,6 @@ class JamfComputerProfileUploaderBase(JamfUploaderBase):
         mobileconfig_contents["PayloadDisplayName"] = mobileconfig_name
         mobileconfig_contents["PayloadIdentifier"] = existing_identifier
         mobileconfig_contents["PayloadUUID"] = existing_uuid
-        # with open(mobileconfig, "wb") as file:
-        #     plistlib.dump(mobileconfig_contents, file)
         return mobileconfig_contents
 
     def make_mobileconfig_from_payload(
@@ -157,30 +155,6 @@ class JamfComputerProfileUploaderBase(JamfUploaderBase):
         self.output(mobileconfig_plist.decode("UTF-8"), verbose_level=2)
 
         return mobileconfig_plist
-
-        # def unsign_signed_mobileconfig(self, mobileconfig_plist):
-        #     """checks if profile is signed. This is necessary because Jamf cannot
-        #     upload a signed profile, so we either need to unsign it, or bail"""
-        #     output_path = os.path.join("/tmp", str(uuid.uuid4()))
-        #     cmd = [
-        #         "/usr/bin/security",
-        #         "cms",
-        #         "-D",
-        #         "-i",
-        #         mobileconfig_plist,
-        #         "-o",
-        #         output_path,
-        #     ]
-        #     self.output(cmd, verbose_level=1)
-
-        # proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        # _, err = proc.communicate()
-        # if os.path.exists(output_path) and os.stat(output_path).st_size > 0:
-        #     self.output(f"Profile is signed. Unsigned profile at {output_path}")
-        #     return output_path
-        # elif err:
-        #     self.output("Profile is not signed.")
-        #     self.output(err, verbose_level=2)
 
     def upload_mobileconfig(
         self,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
@@ -45,7 +45,7 @@ class JamfComputerProfileUploaderBase(JamfUploaderBase):
         """return the existing UUID to ensure we don't change it"""
         # first grab the payload from the xml object
         obj_type = "os_x_configuration_profile"
-        existing_plist = self.get_classic_api_obj_value_from_id(
+        existing_plist = self.get_api_obj_value_from_id(
             jamf_url,
             obj_type,
             obj_id,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
@@ -183,7 +183,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
                 )
 
                 # obtain the MAS app bundleid
-                bundleid = self.get_classic_api_obj_value_from_id(
+                bundleid = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mac_application",
                     obj_id,
@@ -193,7 +193,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
                 if bundleid:
                     self.output(f"Existing bundle ID is '{bundleid}'", verbose_level=1)
                 # obtain the MAS app version
-                macapp_version = self.get_classic_api_obj_value_from_id(
+                macapp_version = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mac_application",
                     obj_id,
@@ -206,7 +206,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
                         verbose_level=1,
                     )
                 # obtain the MAS app free status
-                macapp_is_free = self.get_classic_api_obj_value_from_id(
+                macapp_is_free = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mac_application",
                     obj_id,
@@ -219,7 +219,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
                         verbose_level=1,
                     )
                 # obtain the MAS app URL
-                appstore_url = self.get_classic_api_obj_value_from_id(
+                appstore_url = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mac_application",
                     obj_id,
@@ -232,7 +232,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
                     )
                 # obtain the MAS app icon
                 if not selfservice_icon_uri:
-                    selfservice_icon_uri = self.get_classic_api_obj_value_from_id(
+                    selfservice_icon_uri = self.get_api_obj_value_from_id(
                         jamf_url,
                         "mac_application",
                         obj_id,
@@ -311,7 +311,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
                 self.output(f"MAS app '{clone_from}' already exists: ID {obj_id}")
 
                 # obtain the MAS app bundleid
-                bundleid = self.get_classic_api_obj_value_from_id(
+                bundleid = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mac_application",
                     obj_id,
@@ -321,7 +321,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
                 if bundleid:
                     self.output(f"Existing bundle ID is '{bundleid}'", verbose_level=1)
                 # obtain the MAS app version
-                macapp_version = self.get_classic_api_obj_value_from_id(
+                macapp_version = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mac_application",
                     obj_id,
@@ -334,7 +334,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
                         verbose_level=1,
                     )
                 # obtain the MAS app free status
-                macapp_is_free = self.get_classic_api_obj_value_from_id(
+                macapp_is_free = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mac_application",
                     obj_id,
@@ -347,7 +347,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
                         verbose_level=1,
                     )
                 # obtain the MAS app URL
-                appstore_url = self.get_classic_api_obj_value_from_id(
+                appstore_url = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mac_application",
                     obj_id,
@@ -360,7 +360,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
                     )
                 # obtain the MAS app icon
                 if not selfservice_icon_uri:
-                    selfservice_icon_uri = self.get_classic_api_obj_value_from_id(
+                    selfservice_icon_uri = self.get_api_obj_value_from_id(
                         jamf_url,
                         "mac_application",
                         obj_id,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceAppUploaderBase.py
@@ -218,7 +218,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
                 )
 
                 # obtain the Mobile device app bundleid
-                bundleid = self.get_classic_api_obj_value_from_id(
+                bundleid = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mobile_device_application",
                     obj_id,
@@ -228,7 +228,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
                 if bundleid:
                     self.output(f"Existing bundle ID is '{bundleid}'", verbose_level=1)
                 # obtain the Mobile device app version
-                mobiledeviceapp_version = self.get_classic_api_obj_value_from_id(
+                mobiledeviceapp_version = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mobile_device_application",
                     obj_id,
@@ -241,7 +241,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
                         verbose_level=1,
                     )
                 # obtain the Mobile device app free status
-                mobiledeviceapp_free = self.get_classic_api_obj_value_from_id(
+                mobiledeviceapp_free = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mobile_device_application",
                     obj_id,
@@ -254,7 +254,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
                         verbose_level=1,
                     )
                 # obtain the Mobile device app URL
-                itunes_store_url = self.get_classic_api_obj_value_from_id(
+                itunes_store_url = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mobile_device_application",
                     obj_id,
@@ -268,7 +268,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
                     )
                 # obtain the Mobile device app icon
                 if not selfservice_icon_uri:
-                    selfservice_icon_uri = self.get_classic_api_obj_value_from_id(
+                    selfservice_icon_uri = self.get_api_obj_value_from_id(
                         jamf_url,
                         "mobile_device_application",
                         obj_id,
@@ -297,7 +297,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
                         appconfig_template
                     )
                 else:
-                    appconfig = self.get_classic_api_obj_value_from_id(
+                    appconfig = self.get_api_obj_value_from_id(
                         jamf_url,
                         "mobile_device_application",
                         obj_id,
@@ -370,7 +370,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
                 )
 
                 # obtain the Mobile device app bundleid
-                bundleid = self.get_classic_api_obj_value_from_id(
+                bundleid = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mobile_device_application",
                     obj_id,
@@ -380,7 +380,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
                 if bundleid:
                     self.output(f"Existing bundle ID is '{bundleid}'", verbose_level=1)
                 # obtain the Mobile device app version
-                mobiledeviceapp_version = self.get_classic_api_obj_value_from_id(
+                mobiledeviceapp_version = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mobile_device_application",
                     obj_id,
@@ -393,7 +393,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
                         verbose_level=1,
                     )
                 # obtain the Mobile device app free status
-                mobiledeviceapp_free = self.get_classic_api_obj_value_from_id(
+                mobiledeviceapp_free = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mobile_device_application",
                     obj_id,
@@ -406,7 +406,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
                         verbose_level=1,
                     )
                 # obtain the Mobile device app URL
-                itunes_store_url = self.get_classic_api_obj_value_from_id(
+                itunes_store_url = self.get_api_obj_value_from_id(
                     jamf_url,
                     "mobile_device_application",
                     obj_id,
@@ -420,7 +420,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
                     )
                 # obtain the Mobile device app icon
                 if not selfservice_icon_uri:
-                    selfservice_icon_uri = self.get_classic_api_obj_value_from_id(
+                    selfservice_icon_uri = self.get_api_obj_value_from_id(
                         jamf_url,
                         "mobile_device_application",
                         obj_id,
@@ -445,7 +445,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
                     self.output("Didn't retrieve a VPP ID", verbose_level=2)
                 # obtain appconfig
                 if not appconfig_template:
-                    appconfig = self.get_classic_api_obj_value_from_id(
+                    appconfig = self.get_api_obj_value_from_id(
                         jamf_url,
                         "mobile_device_application",
                         obj_id,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
@@ -46,7 +46,7 @@ class JamfMobileDeviceProfileUploaderBase(JamfUploaderBase):
         """return the existing UUID to ensure we don't change it"""
         # first grab the payload from the xml object
         obj_type = "configuration_profile"
-        existing_plist = self.get_classic_api_obj_value_from_id(
+        existing_plist = self.get_api_obj_value_from_id(
             jamf_url,
             obj_type,
             obj_id,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectDeleterBase.py
@@ -104,11 +104,11 @@ class JamfObjectDeleterBase(JamfUploaderBase):
         )
 
         # declare name key
-        name_key = self.get_name_key(object_type)
+        namekey = self.get_namekey(object_type)
 
         # get the ID from the object bearing the supplied name
         obj_id = self.get_api_obj_id_from_name(
-            jamf_url, object_name, object_type, token=token, filter_name=name_key
+            jamf_url, object_name, object_type, token=token, filter_name=namekey
         )
 
         if obj_id:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -87,7 +87,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
         object_list = []
 
         # declare name key
-        name_key = self.get_name_key(object_type)
+        namekey = self.get_namekey(object_type)
 
         # if requesting all objects we need to generate a list of all to iterate through
         if all_objects or list_only:
@@ -122,7 +122,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
                 object_name,
                 object_type,
                 token=token,
-                filter_name=name_key,
+                filter_name=namekey,
             )
 
             if obj_id:
@@ -130,7 +130,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
                     f"{object_type} '{object_name}' exists: ID {obj_id}",
                     verbose_level=2,
                 )
-                object_list = [{"id": obj_id, name_key: object_name}]
+                object_list = [{"id": obj_id, namekey: object_name}]
             else:
                 self.output(f"{object_type} '{object_name}' not found on {jamf_url}")
                 return
@@ -138,7 +138,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
         # now iterate through all the objects
         for obj in object_list:
             i = obj["id"]
-            n = obj[name_key]
+            n = obj[namekey]
 
             # get the object
             raw_object = self.get_api_obj_contents_from_id(

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -94,7 +94,6 @@ class JamfObjectReaderBase(JamfUploaderBase):
         # declare name key
         namekey = self.get_namekey(object_type)
         namekey_path = self.get_namekey_path(object_type, namekey)
-        self.output(f"namekey_path: {namekey_path}")  # TEMP
 
         # if requesting all objects we need to generate a list of all to iterate through
         if all_objects or list_only:
@@ -111,7 +110,9 @@ class JamfObjectReaderBase(JamfUploaderBase):
                     try:
                         with open(file_path, "w", encoding="utf-8") as fp:
                             json.dump(object_list, fp, indent=4)
-                        self.output(f"Wrote object list to {file_path}")
+                        self.output(
+                            f"Wrote object list to file {file_path}", verbose_level=1
+                        )
                     except IOError as e:
                         raise ProcessorError(
                             f"Could not write output to {file_path} - {str(e)}"
@@ -126,7 +127,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
                 jamf_url, object_type, obj_id, obj_path=namekey_path, token=token
             )
             object_list = [{"id": obj_id, namekey: object_name}]
-            self.output(f"Name: {object_name}")  # TEMP
+            self.output(f"Name: {object_name}", verbose_level=3)
 
         elif object_name:
             # Check for existing item
@@ -165,7 +166,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
                 raw_object, object_type, elements_to_remove
             )
 
-            self.output(parsed_object)
+            self.output(parsed_object, verbose_level=2)
 
             # for certain types we also want to extract the payload
             payload = ""

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -150,6 +150,8 @@ class JamfObjectReaderBase(JamfUploaderBase):
                 raw_object, object_type, elements_to_remove
             )
 
+            self.output(parsed_object)
+
             # for certain types we also want to extract the payload
             payload = ""
             payload_filetype = "sh"
@@ -197,7 +199,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
                         if payload:
                             payload_output_filename = (
                                 f"{subdomain}-{self.object_list_types(object_type)}-{n}"
-                                f".{payload_filetype}"
+                                f".{payload_filetype}".replace(".sh.sh", ".sh")
                             )
                             payload_file_path = os.path.join(
                                 output_dir, payload_output_filename

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -87,6 +87,10 @@ class JamfObjectReaderBase(JamfUploaderBase):
         # declare object list
         object_list = []
 
+        # declare some empty variables
+        output_filename = ""
+        file_path = ""
+
         # declare name key
         namekey = self.get_namekey(object_type)
         namekey_path = self.get_namekey_path(object_type, namekey)
@@ -234,8 +238,8 @@ class JamfObjectReaderBase(JamfUploaderBase):
         self.env["object_type"] = object_type
         self.env["output_dir"] = output_dir
         if not all_objects and not list_only:
-            self.env["output_filename"] = output_filename or None
-            self.env["output_path"] = file_path or None
+            self.env["output_filename"] = output_filename
+            self.env["output_path"] = file_path
             self.env["object_name"] = object_name
             self.env["object_id"] = obj_id
             self.env["raw_object"] = str(raw_object) or None

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -234,8 +234,8 @@ class JamfObjectReaderBase(JamfUploaderBase):
         self.env["object_type"] = object_type
         self.env["output_dir"] = output_dir
         if not all_objects and not list_only:
-            self.env["output_filename"] = output_filename
-            self.env["output_path"] = file_path
+            self.env["output_filename"] = output_filename or None
+            self.env["output_path"] = file_path or None
             self.env["object_name"] = object_name
             self.env["object_id"] = obj_id
             self.env["raw_object"] = str(raw_object) or None

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
@@ -165,7 +165,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
         if "_settings" not in object_type:
             if obj_id:
                 # declare name key
-                name_key = self.get_name_key(object_type)
+                namekey = self.get_namekey(object_type)
                 # define xpath for name based on object type
                 if object_type in (
                     "policy",
@@ -176,9 +176,9 @@ class JamfObjectUploaderBase(JamfUploaderBase):
                     "patch_policy",
                     "restricted_software",
                 ):
-                    obj_path = "general/name"
+                    namekey_path = f"general/{namekey}"
                 else:
-                    obj_path = "name"
+                    namekey_path = "name"
 
                 # if an ID has been passed into the recipe, look for object based on ID rather than name
                 self.output(
@@ -186,7 +186,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
                 )
 
                 existing_object_name = self.get_api_obj_value_from_id(
-                    jamf_url, object_type, obj_id, obj_path=obj_path, token=token
+                    jamf_url, object_type, obj_id, obj_path=namekey_path, token=token
                 )
                 if existing_object_name:
                     self.output(
@@ -210,16 +210,13 @@ class JamfObjectUploaderBase(JamfUploaderBase):
                     f"Checking for existing {object_type} '{object_name}' on {jamf_url}"
                 )
 
-                # declare name key
-                name_key = self.get_name_key(object_type)
-
                 # get the ID from the object bearing the supplied name
                 obj_id = self.get_api_obj_id_from_name(
                     jamf_url,
                     object_name,
                     object_type,
                     token=token,
-                    filter_name=name_key,
+                    filter_name=namekey,
                 )
 
                 if obj_id:
@@ -241,6 +238,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
         else:
             object_name = ""
             obj_id = 0
+            namekey_path = ""
 
         # we need to substitute the values in the object name and template now to
         # account for version strings in the name
@@ -263,6 +261,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
                 object_name,
                 xml_escape=xml_escape,
                 elements_to_remove=elements_to_remove,
+                namekey_path=namekey_path,
             )
 
         # upload the object

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
@@ -118,7 +118,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
         jamf_password = self.env.get("API_PASSWORD")
         client_id = self.env.get("CLIENT_ID")
         client_secret = self.env.get("CLIENT_SECRET")
-        obj_id = self.env.get("id")
+        obj_id = self.env.get("object_id")
         object_name = self.env.get("object_name")
         object_type = self.env.get("object_type")
         object_template = self.env.get("object_template")
@@ -166,19 +166,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
             if obj_id:
                 # declare name key
                 namekey = self.get_namekey(object_type)
-                # define xpath for name based on object type
-                if object_type in (
-                    "policy",
-                    "os_x_configuration_profile",
-                    "configuration_profile",
-                    "mac_application",
-                    "mobile_device_application",
-                    "patch_policy",
-                    "restricted_software",
-                ):
-                    namekey_path = f"general/{namekey}"
-                else:
-                    namekey_path = "name"
+                namekey_path = self.get_namekey_path(object_type, namekey)
 
                 # if an ID has been passed into the recipe, look for object based on ID rather than name
                 self.output(

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
@@ -316,7 +316,7 @@ class JamfPatchUploaderBase(JamfUploaderBase):
                 obj_type = "policy"
                 obj_id = patch_icon_policy_id
                 obj_path = "self_service/self_service_icon/id"
-                patch_icon_id = self.get_classic_api_obj_value_from_id(
+                patch_icon_id = self.get_api_obj_value_from_id(
                     jamf_url,
                     obj_type,
                     obj_id,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
@@ -146,7 +146,7 @@ class JamfPolicyUploaderBase(JamfUploaderBase):
                 )
 
         # Now grab the name of the existing icon using the API
-        existing_icon = self.get_classic_api_obj_value_from_id(
+        existing_icon = self.get_api_obj_value_from_id(
             jamf_url,
             "policy",
             obj_id,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -1093,6 +1093,7 @@ class JamfUploaderBase(Processor):
                 object_xml = ET.fromstring(existing_object)
                 root = ET.ElementTree(object_xml).getroot()
                 parent = root
+                found = None
 
                 # Traverse the XML tree to find the parent of the target element
                 for key in keys:
@@ -1100,15 +1101,19 @@ class JamfUploaderBase(Processor):
                     if found is not None:
                         parent = found
                     else:
-                        raise KeyError(f"Path '{element_path}' not found.")
+                        self.output(
+                            f"Path '{element_path}' not found in template.",
+                            verbose_level=3,
+                        )
 
                 # Find and replace the target element
-                parent.text = new_value
+                if found is not None:
+                    parent.text = new_value
 
-                self.output(
-                    f"Successfully replaced '{element_path}' with '{new_value}'.",
-                    verbose_level=2,
-                )
+                    self.output(
+                        f"Successfully replaced '{element_path}' with '{new_value}'.",
+                        verbose_level=2,
+                    )
                 parsed_xml = ET.tostring(object_xml, encoding="UTF-8")
             except ET.ParseError as xml_error:
                 raise ProcessorError("Could not extract XML") from xml_error

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -148,17 +148,17 @@ class JamfUploaderBase(Processor):
         }
         return object_list_types[object_type]
 
-    def get_name_key(self, object_type):
+    def get_namekey(self, object_type):
         """Return the name key that identifies the object"""
-        name_key = "name"
+        namekey = "name"
         if object_type in (
             "api_client",
             "computer_prestage",
             "mobile_device_prestage",
             "enrollment_customization",
         ):
-            name_key = "displayName"
-        return name_key
+            namekey = "displayName"
+        return namekey
 
     def write_json_file(self, data):
         """dump some json to a temporary file"""
@@ -1134,6 +1134,7 @@ class JamfUploaderBase(Processor):
         object_name=None,
         xml_escape=False,
         elements_to_remove=None,
+        namekey_path=None,
     ):
         """prepare the object contents"""
         # import template from file and replace any keys in the template
@@ -1154,9 +1155,10 @@ class JamfUploaderBase(Processor):
             object_name = self.substitute_assignable_keys(object_name)
 
             # also update the name key to match the given name
-            template_contents = self.replace_xml_element(
-                template_contents, "general/name", object_name
-            )
+            if namekey_path:
+                template_contents = self.replace_xml_element(
+                    template_contents, namekey_path, object_name
+                )
         template_contents = self.substitute_assignable_keys(
             template_contents, xml_escape
         )

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -1095,7 +1095,7 @@ class JamfUploaderBase(Processor):
                 parent = root
 
                 # Traverse the XML tree to find the parent of the target element
-                for key in keys[:-1]:
+                for key in keys:
                     found = parent.find(key)
                     if found is not None:
                         parent = found

--- a/_tests/_ChangePolicyNameTest.jamf.recipe.yaml
+++ b/_tests/_ChangePolicyNameTest.jamf.recipe.yaml
@@ -1,0 +1,23 @@
+Identifier: com.github.grahampugh.recipes.tests.ChangePolicyName
+Comment: |
+  Designed to work in a wrapper script, using an edited JSON file based on a list_only output from JamfObjectReader.
+  Requires:
+  - OBJECT_ID
+  - NEW_NAME
+MinimumVersion: "2.3"
+Input: {}
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfObjectReader
+    Arguments:
+      object_id: "%OBJECT_ID%"
+      object_type: policy
+      output_dir: /Users/Shared/Jamf/JamfUploaderTests
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfObjectUploader
+    Arguments:
+      object_id: "%OBJECT_ID%"
+      object_name: "%NEW_NAME%"
+      object_type: policy
+      object_template: "%output_path%"
+      replace_object: True

--- a/_tests/_DownloadAllPoliciesTest.jamf.recipe.yaml
+++ b/_tests/_DownloadAllPoliciesTest.jamf.recipe.yaml
@@ -1,0 +1,10 @@
+Identifier: com.github.grahampugh.recipes.tests.DownloadAllPolicies
+MinimumVersion: "2.3"
+Input: {}
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfObjectReader
+    Arguments:
+      all_objects: True
+      object_type: policy
+      output_dir: /Users/Shared/Jamf/JamfUploaderTests

--- a/_tests/_DownloadPolicyListTest.jamf.recipe.yaml
+++ b/_tests/_DownloadPolicyListTest.jamf.recipe.yaml
@@ -1,0 +1,10 @@
+Identifier: com.github.grahampugh.recipes.tests.DownloadPolicyList
+MinimumVersion: "2.3"
+Input: {}
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfObjectReader
+    Arguments:
+      list_only: True
+      object_type: policy
+      output_dir: /Users/Shared/Jamf/JamfUploaderTests

--- a/_tests/replace_policy_names.sh
+++ b/_tests/replace_policy_names.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Define the JSON file path
+JSON_FILE="$1"
+
+# Loop through each object in the JSON file
+jq -c '.[]' "$JSON_FILE" | while read -r obj; do
+    id=$(echo "$obj" | jq -r '.id')
+    name=$(echo "$obj" | jq -r '.name')
+
+    # Run the autopkg command with the extracted values
+    echo OBJECT_ID="$id" 
+    echo NEW_NAME="$name"
+    autopkg run -vv _ChangePolicyNameTest.jamf.recipe.yaml --key OBJECT_ID="$id" --key NEW_NAME="$name"
+done

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -172,7 +172,7 @@ case "$test_type" in
             --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
             --type "policy" \
             --id "15" \
-            --name "Firefox" \
+            --name "Firefox - Ongoing" \
             --template "/Users/Shared/Jamf/JamfUploaderTests/jssimporter-policies-Firefox.xml" \
             "$verbosity" \
             --replace

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -278,6 +278,15 @@ case "$test_type" in
             --output "/Users/Shared/Jamf/JamfUploaderTests" \
             "$verbosity"
         ;;
+    read-script-id)
+        "$DIR"/../jamf-upload.sh read \
+            --prefs "$prefs" \
+            --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
+            --type "script" \
+            --id "22" \
+            --output "/Users/Shared/Jamf/JamfUploaderTests" \
+            "$verbosity"
+        ;;
     read-category)
         "$DIR"/../jamf-upload.sh read \
             --prefs "$prefs" \

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -166,6 +166,17 @@ case "$test_type" in
             "$verbosity" \
             --replace
         ;;
+    obj-policy-id)
+        "$DIR"/../jamf-upload.sh obj \
+            --prefs "$prefs" \
+            --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
+            --type "policy" \
+            --id "15" \
+            --name "Firefox" \
+            --template "/Users/Shared/Jamf/JamfUploaderTests/jssimporter-policies-Firefox.xml" \
+            "$verbosity" \
+            --replace
+        ;;
     read-distributionpoint)
         "$DIR"/../jamf-upload.sh read \
             --prefs "$prefs" \

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -177,6 +177,17 @@ case "$test_type" in
             "$verbosity" \
             --replace
         ;;
+    obj-script-id)
+        "$DIR"/../jamf-upload.sh obj \
+            --prefs "$prefs" \
+            --recipe-dir /Users/gpugh/sourcecode/jamf-upload/_tests \
+            --type "script" \
+            --id "22" \
+            --name "Spotify-postinstall.sh" \
+            --template "/Users/Shared/Jamf/JamfUploaderTests/jssimporter-scripts-SpotifyPostinstall.sh.json" \
+            "$verbosity" \
+            --replace
+        ;;
     read-distributionpoint)
         "$DIR"/../jamf-upload.sh read \
             --prefs "$prefs" \

--- a/jamf-upload.sh
+++ b/jamf-upload.sh
@@ -114,6 +114,7 @@ Computer Extension Attribute Upload arguments:
 
 Generic Object Upload arguments:
     --name <string>         The name
+    --id <string>           The ID, can be used instead of --name to specify an ID
     --type <string>         The API object type. This is the name of the key in the XML template.
     --template <path>       XML template
     --output <dir>          Optional directory to output the parsed XML to. Directory must exist.
@@ -1034,6 +1035,14 @@ while test $# -gt 0 ; do
             if [[ $processor == "JamfObjectReader" ]]; then
                 if plutil -replace list_only -string "True" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote list_only='True' into $temp_processor_plist"
+                fi
+            fi
+            ;;
+        --id)
+            shift
+            if [[ $processor == "JamfObjectUploader" ]]; then
+                if plutil -replace id -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote id='$1' into $temp_processor_plist"
                 fi
             fi
             ;;

--- a/jamf-upload.sh
+++ b/jamf-upload.sh
@@ -1040,9 +1040,9 @@ while test $# -gt 0 ; do
             ;;
         --id)
             shift
-            if [[ $processor == "JamfObjectUploader" ]]; then
-                if plutil -replace id -string "$1" "$temp_processor_plist"; then
-                    echo "   [jamf-upload] Wrote id='$1' into $temp_processor_plist"
+            if [[ $processor == "JamfObjectReader" || $processor == "JamfObjectUploader" ]]; then
+                if plutil -replace object_id -string "$1" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote object_id='$1' into $temp_processor_plist"
                 fi
             fi
             ;;


### PR DESCRIPTION
Supply `id` to JamfObjectUploader., it will upload the template to this ID instead of to a `name`. If you also supply a `name` value, it will replace the existing name in the template and upload to the `id`.