### PR TITLE
Update JamfObjectReaderBase.py - Initialise payload_output_filename and payload_file_path

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -169,6 +169,8 @@ class JamfObjectReaderBase(JamfUploaderBase):
             self.output(parsed_object, verbose_level=2)
 
             # for certain types we also want to extract the payload
+            payload_output_filename = ""
+            payload_file_path = ""
             payload = ""
             payload_filetype = "sh"
             if object_type == "computer_extension_attribute":


### PR DESCRIPTION
Initialise payload_output_filename and payload_file_path to avoid processor failing when reading an os_x_configuration_profile object.

Otherwise we get:

```
Getting Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 626, in process
    self.main()
  File "/Users/Shared/GitHub/jamf-upload/JamfUploaderProcessors/JamfObjectReader.py", line 150, in main
    self.execute()
  File "/Users/Shared/GitHub/jamf-upload/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py", line 249, in execute
    self.env["payload_output_filename"] = payload_output_filename
UnboundLocalError: local variable 'payload_output_filename' referenced before assignment
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
local variable 'payload_output_filename' referenced before assignment
```