### PR TITLE
Update JamfObjectUploaderBase.py - handle _register object types

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
@@ -156,7 +156,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
         namekey_path = self.get_namekey_path(object_type, namekey)
 
         # check for an existing object except for settings-related endpoints
-        if "_settings" not in object_type and "_command" not in object_type:
+        if not any(suffix in object_type for suffix in ("_settings", "_register", "_command")):
             if obj_id:
 
                 # if an ID has been passed into the recipe, look for object based on ID


### PR DESCRIPTION
Processor failed when used against `jamf_protect_register` as was attempting to get an object ID with get_api_obj_id_from_name. This object type does not have an ID or name and always expects a payload to be POSTed to it.

Should be handled correctly with this change (have tested with `_settings` `_command` and `os_x_configuration_profile` object types and all upload as expected).