### PR TITLE
Fix an issue where return statement isn't always reachable

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
@@ -442,7 +442,7 @@ class JamfPackageUploaderBase(JamfUploaderBase):
             else:
                 sleep(30)
 
-            return credentials
+        return credentials
 
     def upload_to_jcds2_s3_bucket(
         self,


### PR DESCRIPTION
This change fixes an issue whereby the return statement in `initiate_jcds2_upload()` is not always reachable - if the HTTP response check in `self.status_check()` returns the expected value, we break out of the `while` loop that also contains the return statement. 

In our environment, this had caused issues uploading packages.