### PR TITLE
fix: JamfObjectReader - convert object_id to string

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -280,7 +280,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
             self.env["output_filename"] = output_filename
             self.env["output_path"] = file_path
             self.env["object_name"] = object_name
-            self.env["object_id"] = obj_id
+            self.env["object_id"] = str(obj_id)
             self.env["raw_object"] = str(raw_object)
             self.env["parsed_object"] = str(parsed_object)
             if payload:

--- a/JamfUploaderProcessors/JamfUploaderSlacker.py
+++ b/JamfUploaderProcessors/JamfUploaderSlacker.py
@@ -120,6 +120,7 @@ class JamfUploaderSlacker(JamfUploaderBase):
     def main(self):
         """Do the main thing"""
         jss_url = self.env.get("JSS_URL")
+        failover_url = self.env.get("failover_url")
         policy_category = self.env.get("POLICY_CATEGORY")
         category = self.env.get("PKG_CATEGORY")
         policy_name = self.env.get("policy_name")
@@ -257,10 +258,13 @@ class JamfUploaderSlacker(JamfUploaderBase):
             )
         elif jamfobjectuploader_summary_result:
             slack_text = (
-                f"*{object_type} uploaded to Jamf Pro:*\n"
-                + f"URL: {jss_url}\n"
-                + f"Name: *{object_name}*"
+                f"*{object_type} uploaded to Jamf Pro:*"
+                + f"\nURL: {jss_url}"
             )
+            if object_name:
+                slack_text += f"\nName: *{object_name}*"
+            if failover_url:
+                slack_text += f"\nFailover URL: {failover_url}"
         else:
             self.output("Nothing to report to Slack")
             return


### PR DESCRIPTION
Couldn't do variable substitution using output variable `object_id` as it's an integer. Forcing it to string works as expected.

```
com.github.grahampugh.jamf-upload.processors/JamfPolicyUploader
Traceback (most recent call last):
  File "/usr/local/bin/autopkg", line 2786, in <module>
    sys.exit(main(sys.argv))
  File "/usr/local/bin/autopkg", line 2782, in main
    return subcommands[verb]["function"](argv)
  File "/usr/local/bin/autopkg", line 2278, in run_recipes
    autopackager.process(recipe)
  File "/Library/AutoPkg/autopkglib/__init__.py", line 828, in process
    processor.inject(step.get("Arguments", {}))
  File "/Library/AutoPkg/autopkglib/__init__.py", line 608, in inject
    update_data(self.env, key, value)
  File "/Library/AutoPkg/autopkglib/__init__.py", line 453, in update_data
    a_dict[key] = do_variable_substitution(value)
  File "/Library/AutoPkg/autopkglib/__init__.py", line 435, in do_variable_substitution
    item = RE_KEYREF.sub(getdata, item)
TypeError: sequence item 0: expected str instance, int found
```