### PR TITLE
Move the `curl` `headers_file` to each session's temp dir

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -545,7 +545,7 @@ class JamfUploaderBase(Processor):
         tmp_dir = self.make_tmp_dir()
         url_specific_dir = self.make_url_specific_dir(url)
         headers_file = os.path.join(
-            url_specific_dir, "curl_headers_from_jamf_upload.txt"
+            tmp_dir, "curl_headers_from_jamf_upload.txt"
         )
         output_file = self.init_temp_file(prefix="jamf_upload_", suffix=".txt")
         cookie_jar = os.path.join(url_specific_dir, "curl_cookies_from_jamf_upload.txt")


### PR DESCRIPTION
The `headers_file` must remain in the unique directory for each session as that file contains the return content for each individual `curl` call, specifically the HTTP status code, which is checked before moving forward.

Using the same file for all sessions means the status code is being overwritten by different sessions' `curl` calls and when the `headers_file` is read back in, it may get the HTTP status code of a different sessions' `curl` execution.

This fixes/reverts a change in #247.