### PR TITLE
Allow missing script name and add skip substitution option

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
@@ -178,6 +178,9 @@ class JamfScriptUploaderBase(JamfUploaderBase):
         # we need to substitute the values in the script name now to
         # account for generated strings in the name
         # substitute user-assignable keys
+        if not script_name:
+            script_name = os.path.basename(script_path)
+
         script_name = self.substitute_assignable_keys(script_name)
 
         # get token using oauth or basic auth depending on the credentials given
@@ -224,9 +227,6 @@ class JamfScriptUploaderBase(JamfUploaderBase):
                 raise ProcessorError(f"ERROR: Script file {script_path} not found")
 
         # now start the process of uploading the object
-        if not script_name:
-            script_name = os.path.basename(script_path)
-
         # check for existing script
         self.output(f"Checking for existing '{script_name}' on {jamf_url}")
         self.output(

--- a/jamf-upload.sh
+++ b/jamf-upload.sh
@@ -288,6 +288,8 @@ Script Upload arguments:
     --key X=Y               Substitutable values in the script. Multiple values can be supplied
     --parameter[4-11]
                             Script parameter labels 
+    --skip-substitution
+                            Skip substitution of variables in the script
     --replace               Replace existing item
 
 Software Restriction Upload arguments:
@@ -1438,6 +1440,13 @@ while test $# -gt 0 ; do
             if [[ $processor == "JamfScriptUploader" ]]; then
                 if plutil -replace "script_parameter$param_number" -string "$1" "$temp_processor_plist"; then
                     echo "   [jamf-upload] Wrote script_parameter$param_number='$1' into $temp_processor_plist"
+                fi
+            fi
+            ;;
+        --skip-substitution) 
+            if [[ $processor == "JamfScriptUploader" ]]; then
+                if plutil -replace skip_script_key_substitution -string "True" "$temp_processor_plist"; then
+                    echo "   [jamf-upload] Wrote skip_script_key_substitution='True' into $temp_processor_plist"
                 fi
             fi
             ;;


### PR DESCRIPTION
Enable the handling of missing script names by using the base name of the script path. Introduce a new option to skip variable substitution in scripts.