### PR TITLE
Added display name to the request for creating an API client

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAPIClientUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAPIClientUploaderBase.py
@@ -232,6 +232,7 @@ class JamfAPIClientUploaderBase(JamfUploaderBase):
         # build the object
         object_data = {
             "authorizationScopes": [api_role_name],
+            "displayName": object_name,
             "enabled": api_client_enabled,
             "accessTokenLifetimeSeconds": int(access_token_lifetime),
         }


### PR DESCRIPTION
It seems that the Jamf API now expects for the API client name to be included in the request JSON.

The `JamfAPIClientUploader` processor has been working for me in the past (and doesn't seem to have been changed) but now seems to just give a generic 500 error with no helpful output from the Jamf API. After a bit of digging I discovered that JamfUploader is creating a json data file with this content below:

`{"authorizationScopes": ["AutoPkgAPI"], "enabled": false, "accessTokenLifetimeSeconds": 300}`
Note: `AutoPkgAPI` is my role name not client name.

Looking in the Swagger API documentation seemed to suggest that "displayName" was a required part of the request. Changing the json to the below value created the API client correctly:

`{"authorizationScopes": ["AutoPkgAPI"], "displayName": "API Client Name", "enabled": false, "accessTokenLifetimeSeconds": 300}`

I've made this small change to the `JamfAPIClientUploaderBase.py` file and hopefully I selected the correct variable `object_name` to fill in here. I tested this change in my local copy of JamfUploader with AutoPkg and this seems to resolve the issue; both for creating a new API account (PUSH) and also for updating/replacing an existing one (PUT).

Please let me know if there is anything else I can do to help clarify or test this code.