### PR TITLE
Add recalculate-wait-time option

### DIFF
--- a/JamfUploaderProcessors/JamfPackageUploader.py
+++ b/JamfUploaderProcessors/JamfPackageUploader.py
@@ -266,6 +266,11 @@ class JamfPackageUploader(JamfPackageUploaderBase):
             "description": "Recalculate cloud distribution point inventory.",
             "default": "False",
         },
+        "recalculate_wait_time": {
+            "required": False,
+            "description": "Time to wait for recalculation to complete.",
+            "default": "False",
+        },
         "sleep": {
             "required": False,
             "description": "Pause after running this processor for specified seconds.",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
@@ -535,6 +535,7 @@ class JamfPackageUploaderBase(JamfUploaderBase):
         skip_metadata_upload = self.to_bool(self.env.get("skip_metadata_upload"))
         aws_cdp_mode = self.to_bool(self.env.get("aws_cdp_mode"))
         recalculate = self.to_bool(self.env.get("recalculate"))
+        recalculate_wait_time = self.env.get("recalculate_wait_time")
         use_md5 = self.env.get("md5")
         jamf_url = (self.env.get("JSS_URL") or "").rstrip("/")
         jamf_user = self.env.get("API_USERNAME")
@@ -936,6 +937,14 @@ class JamfPackageUploaderBase(JamfUploaderBase):
         ):
             # check token again using oauth or basic auth depending on the credentials given
             # as package upload may have taken some time
+
+            # first sleep if recalculate_wait_time is set, to give the system time to process the package upload before we send the recalculation request
+            if recalculate_wait_time and int(recalculate_wait_time) > 0:
+                self.output(
+                    f"Waiting {recalculate_wait_time} seconds before sending Cloud DP inventory recalculation request",
+                    verbose_level=2,
+                )
+                sleep(int(recalculate_wait_time))
             # get token using oauth or basic auth depending on the credentials given
             if jamf_url:
                 token, jamf_url, jamf_platform_gw_region, jamf_platform_gw_tenant_id = (

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -72,6 +72,7 @@ while [[ "$#" -gt 0 ]]; do
         echo "  read-group"
         echo "  list-policies"
         echo "  list-policies-user"
+        echo "  list-pkgs"
         echo "  list-scripts"
         echo "  list-computer-groups"
         echo "  scope"
@@ -141,6 +142,7 @@ while [[ "$#" -gt 0 ]]; do
         echo "  patch"
         echo "  patch2"
         echo "  pkg"
+        echo "  pkgplusrecalc"
         echo "  dock"
         echo "  icon"
         echo "  apirole"
@@ -420,6 +422,19 @@ list-policies-user)
         --type "policy"
         --list
         --key CLIENT_ID=c611d89d-471b-40d2-855d-08647131fc1d
+    )
+    # now print out the command that will be executed, and run the command
+    printf '%s\n' "Executing command: $(printf '%s ' "${command[@]}")"
+    "${command[@]}"
+
+    ;;
+list-pkgs)
+    command=(
+        "${command_base[@]}"
+        read
+        --type "package"
+        --all
+        --list
     )
     # now print out the command that will be executed, and run the command
     printf '%s\n' "Executing command: $(printf '%s ' "${command[@]}")"
@@ -1419,6 +1434,23 @@ pkg)
         --category "JamfUploadTest"
         --info "Uploaded directly by JamfPackageUploader using v1/packages"
         --notes "$(date)"
+        --replace
+    )
+    # now print out the command that will be executed, and run the command
+    printf '%s\n' "Executing command: $(printf '%s ' "${command[@]}")"
+    "${command[@]}"
+
+    ;;
+pkgplusrecalc)
+    command=(
+        "${command_base[@]}"
+        pkg
+        --pkg "$pkg_path"
+        --category "JamfUploadTest"
+        --info "Uploaded directly by JamfPackageUploader using v1/packages"
+        --notes "$(date)"
+        --recalculate
+        --recalculate-wait-time 60
         --replace
     )
     # now print out the command that will be executed, and run the command

--- a/jamf-upload.sh
+++ b/jamf-upload.sh
@@ -256,6 +256,9 @@ Package Upload arguments:
     --aws                   Use AWS CDP for package upload. Requires aws-cli to be installed 
     --api                   Use v1/packages endpoint for package upload to cloud DP
     --recalculate           Recalculate packages if using --jcds2 or --api modes
+    --recalculate-wait-time <int>
+                            Time to wait for recalculation to complete, in seconds. 
+                            Only applicable if --recalculate is set.
     --md5                   Use MD5 hash instead of SHA512. Required for packages 
                             to be installable via MDM InstallEnterpriseApplication
 
@@ -1624,6 +1627,14 @@ while test $# -gt 0; do
         if [[ $processor == "JamfPackageUploader" ]]; then
             if plutil -replace recalculate -string "true" "$temp_processor_plist"; then
                 echo "   [jamf-upload] Wrote recalculate='True' into $temp_processor_plist"
+            fi
+        fi
+        ;;
+    --recalculate-wait-time)
+        shift
+        if [[ $processor == "JamfPackageUploader" ]]; then
+            if plutil -replace recalculate_wait_time -string "$1" "$temp_processor_plist"; then
+                echo "   [jamf-upload] Wrote recalculate_wait_time='$1' into $temp_processor_plist"
             fi
         fi
         ;;


### PR DESCRIPTION
Introduce a new option to specify a wait time for recalculation to complete after a package upload. This enhancement allows users to control the delay before sending the recalculation request, improving the upload process's reliability. Additionally, update command-line arguments and documentation to reflect this new feature.