### PR TITLE
Refresh package upload process and update to SHA3_512

### DIFF
--- a/JamfUploaderProcessors/JamfPackageUploader.py
+++ b/JamfUploaderProcessors/JamfPackageUploader.py
@@ -269,12 +269,12 @@ class JamfPackageUploader(JamfPackageUploaderBase):
         "recalculate_wait_time": {
             "required": False,
             "description": "Time to wait for recalculation to complete.",
-            "default": "False",
+            "default": 0,
         },
         "sleep": {
             "required": False,
             "description": "Pause after running this processor for specified seconds.",
-            "default": "0",
+            "default": 0,
         },
         "max_tries": {
             "required": False,
@@ -282,7 +282,7 @@ class JamfPackageUploader(JamfPackageUploaderBase):
                 "Maximum number of attempts to upload the account. "
                 "Must be an integer between 1 and 10."
             ),
-            "default": "5",
+            "default": 5,
         },
     }
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
@@ -30,7 +30,6 @@ import os.path
 import shutil
 import subprocess
 import sys
-import threading
 
 from shutil import copyfile
 from time import sleep
@@ -46,27 +45,6 @@ sys.path.insert(0, os.path.dirname(__file__))
 from JamfUploaderBase import (  # pylint: disable=import-error, wrong-import-position
     JamfUploaderBase,
 )
-
-
-class ProgressPercentage(object):
-    """Class for displaying upload progress - used for jcds2_mode only"""
-
-    def __init__(self, filename):
-        self._filename = filename
-        self._size = float(os.path.getsize(filename))
-        self._seen_so_far = 0
-        self._lock = threading.Lock()
-
-    def __call__(self, bytes_amount):
-        # To simplify, assume this is hooked up to a single filename
-        with self._lock:
-            self._seen_so_far += bytes_amount
-            percentage = (self._seen_so_far / self._size) * 100
-            sys.stdout.write(
-                "\r%s  %s / %s  (%.2f%%)"  # pylint: disable=consider-using-f-string
-                % (self._filename, self._seen_so_far, self._size, percentage)
-            )
-            sys.stdout.flush()
 
 
 class JamfPackageUploaderBase(JamfUploaderBase):
@@ -370,7 +348,7 @@ class JamfPackageUploaderBase(JamfUploaderBase):
         pkg_name,
         pkg_display_name,
         pkg_metadata,
-        sha512string,
+        sha3string,
         md5string,
         sleep_time,
         token,
@@ -411,10 +389,10 @@ class JamfPackageUploaderBase(JamfUploaderBase):
             hash_type = "MD5"
             pkg_data["hashType"] = hash_type
             pkg_data["hashValue"] = md5string
-        elif sha512string:
-            hash_type = "SHA_512"
+        elif sha3string:
+            hash_type = "SHA3_512"
             pkg_data["hashType"] = hash_type
-            pkg_data["hashValue"] = sha512string
+            pkg_data["hashValue"] = sha3string
 
         self.output(
             "Package metadata:",
@@ -478,12 +456,18 @@ class JamfPackageUploaderBase(JamfUploaderBase):
     # ------------------------------------------------------------------------
     # Begin function for recalulating inventory on Cloud Distribution Point (for pkg_api_mode)
 
-    def recalculate_packages(self, api_url, token, tenant_id=""):
+    def recalculate_packages(self, api_url, token, tenant_id="", pkg_name=""):
         """Send a request to recalulate the Cloud Distribution Point inventory"""
         # get the Cloud Distribution Point file list
         object_type = "cloud_distribution_point"
         endpoint = self.api_endpoints(object_type, tenant_id=tenant_id)
         url = f"{api_url}/{endpoint}/refresh-inventory"
+        if pkg_name:
+            self.output(
+                f"Requesting Cloud Distribution Point inventory refresh for package {pkg_name}",
+                verbose_level=1,
+            )
+            url += f"?file-name={pkg_name}"
 
         request = "POST"
         r = self.curl(
@@ -494,15 +478,21 @@ class JamfPackageUploaderBase(JamfUploaderBase):
         )
 
         if r.status_code == 204:
-            self.output(
-                "Cloud Distribution Point inventory successfully recalculated",
-                verbose_level=2,
-            )
+            if pkg_name:
+                self.output(
+                    f"Cloud Distribution Point inventory refresh requested for package {pkg_name}",
+                    verbose_level=2,
+                )
+            else:
+                self.output(
+                    "Cloud Distribution Point global inventory refresh requested",
+                    verbose_level=2,
+                )
             packages_recalculated = True
         else:
             self.output(
                 "WARNING: Cloud Distribution Point inventory NOT successfully "
-                f"recalculated (response={r.status_code})",
+                f"refreshed (response={r.status_code})",
                 verbose_level=1,
             )
             packages_recalculated = False
@@ -683,13 +673,13 @@ class JamfPackageUploaderBase(JamfUploaderBase):
         if not pkg_display_name:
             pkg_display_name = pkg_name
 
-        # calculate the SHA-512 hash of the package
-        sha512string = self.sha512sum(pkg_path)
+        # calculate the SHA-3-512 hash of the package
+        sha3string = self.sha3sum(pkg_path)
 
         # calculate the SHA-256 hash of the package
         # sha256string = self.sha256sum(pkg_path)
 
-        # calculate the SHA-512 hash of the package
+        # calculate the MD5 hash of the package
         md5string = self.md5sum(pkg_path) if use_md5 else None
 
         # now start the process of uploading the package
@@ -861,7 +851,7 @@ class JamfPackageUploaderBase(JamfUploaderBase):
                 pkg_name,
                 pkg_display_name,
                 pkg_metadata,
-                sha512string,
+                sha3string,
                 md5string,
                 sleep_time,
                 token=token,
@@ -883,7 +873,7 @@ class JamfPackageUploaderBase(JamfUploaderBase):
                 pkg_name,
                 pkg_display_name,
                 pkg_metadata,
-                sha512string,
+                sha3string,
                 md5string,
                 sleep_time,
                 token=token,
@@ -928,12 +918,12 @@ class JamfPackageUploaderBase(JamfUploaderBase):
             # if we get this far then there was a 200 success response so the package was uploaded
             pkg_uploaded = True
 
-        # recalculate packages on JCDS if the metadata was updated and recalculation requested
+        # recalculate packages on JCDS if the metadata was updated
+        # if recalculate is set, we'll do a global refresh, otherwise we'll just refresh the package that was updated
         # Jamf Pro 11.10+ only
         if (
             APLooseVersion(jamf_pro_version) >= APLooseVersion("11.10")
             and pkg_metadata_updated
-            and recalculate
         ):
             # check token again using oauth or basic auth depending on the credentials given
             # as package upload may have taken some time
@@ -941,7 +931,7 @@ class JamfPackageUploaderBase(JamfUploaderBase):
             # first sleep if recalculate_wait_time is set, to give the system time to process the package upload before we send the recalculation request
             if recalculate_wait_time and int(recalculate_wait_time) > 0:
                 self.output(
-                    f"Waiting {recalculate_wait_time} seconds before sending Cloud DP inventory recalculation request",
+                    f"Waiting {recalculate_wait_time} seconds before sending Cloud DP inventory refresh request",
                     verbose_level=2,
                 )
                 sleep(int(recalculate_wait_time))
@@ -965,7 +955,10 @@ class JamfPackageUploaderBase(JamfUploaderBase):
 
             # now send the recalculation request
             packages_recalculated = self.recalculate_packages(
-                api_url, token, jamf_platform_gw_tenant_id
+                api_url,
+                token,
+                jamf_platform_gw_tenant_id,
+                pkg_name=None if recalculate else pkg_name,
             )
         else:
             packages_recalculated = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -1388,8 +1388,12 @@ class JamfUploaderBase(Processor):
                     "No existing cookie found - starting new session", verbose_level=2
                 )
 
-            # all endpoints can be specified silent with show-error
-            curl_cmd.extend(["--silent", "--show-error"])
+            # all endpoints can be specified with show-error
+            curl_cmd.extend(["--show-error"])
+
+            # we want to be silent except for package uploads
+            if endpoint_type != "package_v1":
+                curl_cmd.extend(["--silent"])
 
             # icon download
             if endpoint_type == "icon_get":
@@ -1407,6 +1411,7 @@ class JamfUploaderBase(Processor):
 
             # package upload (Jamf Pro API)
             elif endpoint_type == "package_v1":
+                curl_cmd.extend(["--progress-bar"])
                 curl_cmd.extend(["--header", "Content-type: multipart/form-data"])
                 curl_cmd.extend(["--form", f"file=@{data}"])
 

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -112,6 +112,7 @@ while [[ "$#" -gt 0 ]]; do
         echo "  category"
         echo "  group"
         echo "  delete-group"
+        echo "  delete-pkg"
         echo "  delete-script"
         echo "  mobiledevicegroup"
         echo "  msu"
@@ -131,7 +132,7 @@ while [[ "$#" -gt 0 ]]; do
         echo "  mobiledeviceapp-fromread"
         echo "  mobiledeviceprofile"
         echo "  policy"
-        echo "  policy_retain_scope"
+        echo "  policy-retain-scope"
         echo "  prestage"
         echo "  prestage2"
         echo "  account"
@@ -142,12 +143,12 @@ while [[ "$#" -gt 0 ]]; do
         echo "  patch"
         echo "  patch2"
         echo "  pkg"
-        echo "  pkgplusrecalc"
+        echo "  pkg-plus-calc"
         echo "  dock"
         echo "  icon"
         echo "  apirole"
         echo "  apiclient"
-        echo "  policydelete"
+        echo "  delete-policy"
         echo "  policyflush"
         echo "  pkg-noreplace"
         echo "  pkg-jcds2"
@@ -963,6 +964,18 @@ delete-script)
     "${command[@]}"
 
     ;;
+delete-pkg)
+    command=(
+        "${command_base[@]}"
+        delete
+        --type "package"
+        --name "$pkg_path"
+    )
+    # now print out the command that will be executed, and run the command
+    printf '%s\n' "Executing command: $(printf '%s ' "${command[@]}")"
+    "${command[@]}"
+
+    ;;
 mobiledevicegroup)
     command=(
         "${command_base[@]}"
@@ -1254,7 +1267,7 @@ policy)
     "${command[@]}"
 
     ;;
-policy_retain_scope)
+policy-retain-scope)
     command=(
         "${command_base[@]}"
         policy
@@ -1441,7 +1454,7 @@ pkg)
     "${command[@]}"
 
     ;;
-pkgplusrecalc)
+pkg-plus-calc*)
     command=(
         "${command_base[@]}"
         pkg
@@ -1450,7 +1463,6 @@ pkgplusrecalc)
         --info "Uploaded directly by JamfPackageUploader using v1/packages"
         --notes "$(date)"
         --recalculate
-        --recalculate-wait-time 60
         --replace
     )
     # now print out the command that will be executed, and run the command
@@ -1522,7 +1534,7 @@ apiclient)
     "${command[@]}"
 
     ;;
-policydelete)
+delete-policy)
     command=(
         "${command_base[@]}"
         policydelete


### PR DESCRIPTION
Enhance the package upload process by implementing a refresh mechanism for all package uploads. This includes updates to hash calculations and improvements in output messaging for inventory refresh requests. Additionally, streamline the command-line interface for package management.

Note that there could be issues with the SHA3_512 on older versions of Jamf Pro (pre 11.25)