### PR TITLE
Add dry_run option to jamf-upload functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**jamf-upload** is a toolkit for interacting with the Jamf Pro API (macOS/iOS device management). It has two main components:
+
+1. **AutoPkg Processors** (`JamfUploaderProcessors/`) — 43+ Python processors extending AutoPkg
+2. **Standalone shell script** (`jamf-upload.sh`) — direct API interaction without AutoPkg
+
+Identical copies of the processors are hosted in `autopkg/grahampugh-recipes`. PRs should only be made to this repo (`grahampugh/jamf-upload`).
+
+## Python Environment
+
+All processor files use AutoPkg's Python distribution with shebang `#!/usr/local/autopkg/python`. Do not use the system Python or a venv for running processors — they depend on `autopkglib` which lives in AutoPkg's distribution.
+
+For linting/development tools, a `.venv` is available:
+
+```sh
+source .venv/bin/activate
+flake8 JamfUploaderProcessors/          # max line length: 100 (configured in setup.cfg)
+pylint JamfUploaderProcessors/          # config in .pylintrc
+```
+
+## Architecture
+
+### Processor pattern (thin wrapper + base class)
+
+Every processor follows this split:
+
+- **`JamfUploaderProcessors/JamfFooUploader.py`** — thin wrapper that defines AutoPkg `input_variables` / `output_variables` and extends the base class. Contains no logic.
+- **`JamfUploaderProcessors/JamfUploaderLib/JamfFooUploaderBase.py`** — contains all implementation logic.
+
+The base classes all extend `JamfUploaderBase` (`JamfUploaderLib/JamfUploaderBase.py`), which provides:
+
+- Authentication: basic auth, OAuth bearer tokens, API client credentials
+- HTTP communication via `curl` subprocess calls (not the `requests` library directly, because this is not included in the autopkg python distribution)
+- XML/JSON template substitution
+- Jamf Pro version detection
+- Schema registry integration
+
+### Schema registry (`JamfSchemaRegistry.py`)
+
+`JamfSchemaRegistry` dynamically discovers API endpoints by downloading and caching the Jamf Pro OpenAPI (JPAPI) and Classic API Swagger schemas at runtime. It maps `object_type` strings to endpoint metadata. `CLASSIC_ALIAS_TABLE` and `JPAPI_ALIAS_TABLE` map JamfUploader internal names to schema resource names when simple normalisation isn't sufficient.
+
+### Two API families
+
+- **Classic API** — XML-based, older endpoints (most object types)
+- **Jamf Pro API (JPAPI)** — JSON-based, newer endpoints (packages v1/v3, prestages, etc.)
+
+Many processors support both; version detection in `JamfUploaderBase` determines which to use.
+
+### Package upload modes
+
+`JamfPackageUploader` supports multiple distribution point backends:
+
+- **JCDS2** — Jamf Cloud Distribution Service (AWS S3 multipart)
+- **AWS CDP** — Customer-owned S3 bucket
+- **SMB** — SMB/CIFS share
+- **dbfileupload** — Legacy Classic API upload
+- **v1/v3 packages API** — Newer REST endpoints
+
+## Tests
+
+Test scripts and recipes live in `_tests/`. These are mostly shell scripts that exercise the API against a real Jamf Pro server — there is no mock-based unit test suite. Key test scripts:
+
+```sh
+_tests/api_test_pkg.sh          # Test package upload (default mode)
+_tests/api_test_pkg_jcds2.sh    # Test JCDS2 mode
+_tests/api_test_pkg_aws_cdp.sh  # Test AWS CDP mode
+_tests/test_schema_registry.py  # Schema registry unit tests (runnable with autopkg python)
+```
+
+To run the schema registry tests:
+
+```sh
+/usr/local/autopkg/python _tests/test_schema_registry.py
+```
+
+The file `_tests/test.py` contains many preset tests that can be run by selecting a test with the `-t` parameter.
+
+## Adding a new processor
+
+1. Create `JamfUploaderProcessors/JamfFooUploader.py` — thin wrapper only, with `input_variables`, `output_variables`, and a `main()` that calls the base class.
+2. Create `JamfUploaderProcessors/JamfUploaderLib/JamfFooUploaderBase.py` — all logic here, extending `JamfUploaderBase`.
+3. Add documentation in `JamfUploaderProcessors/READMEs/`.
+4. If the new object type needs schema resolution, add an entry to `CLASSIC_ALIAS_TABLE` or `JPAPI_ALIAS_TABLE` in `JamfSchemaRegistry.py`.
+
+## Key references
+
+- Wiki: <https://github.com/grahampugh/jamf-upload/wiki>
+- Processor input/output docs: `JamfUploaderProcessors/READMEs/`
+- Changelog: `JamfUploaderProcessors/CHANGELOG.md`

--- a/JamfUploaderProcessors/CHANGELOG.md
+++ b/JamfUploaderProcessors/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 The dates here represent when the features were added to the processors in the `jamf-upload` repo.
 
+## 2026-05-29
+
+* Added `dry_run` option to all processors. When set to `True`, processors perform read-only checks and report what would change without making any writes to the Jamf Pro server.
+* Made the curl progress bar during package upload optional via the `show_upload_progress` input parameter in `JamfPackageUploader`. Progress output is now disabled by default to avoid interfering with logging systems.
+
+## 2026-05-08
+
+* (#380) URL-encode the package name when checking for existing packages in `JamfPackageUploaderBase` to handle packages with special characters in their names.
+
+## 2026-05-04
+
+* (#376) Added `skip_if` predicate support to all processors, allowing a process to be skipped based on an NSPredicate expression evaluated against the AutoPkg environment.
+* (#377) Updated `output_variables` descriptions across all processors for consistency.
+* (#378) Added `skip_if` documentation to `JamfAccountUploader`.
+
+## 2026-04-23
+
+* (#372) Fixed VPP location retrieval in `JamfMacAppUploader` and `JamfMobileDeviceAppUploader` to use paginated results when checking available VPP locations.
+* (#373) Added `recalculate_wait_time` option to `JamfPackageUploader`, allowing a delay before sending a Cloud Distribution Point inventory refresh request after a package upload.
+* (#374) Updated `JamfPackageUploader` to allow per-package Cloud Distribution Point inventory refresh (in addition to the existing global refresh option).
+
+## 2026-04-19
+
+* (#370) Added `JamfSchemaRegistry` for dynamic API schema discovery, replacing hardcoded endpoint tables. Added support for the Jamf Platform Gateway API and `jamf-cli`-based authentication. Added `BEARER_TOKEN`, `JAMF_CLI_PROFILE`, `PLATFORM_API_REGION`, and `PLATFORM_API_TENANT_ID` input variables to all processors.
+
+## 2026-04-12
+
+* (#371) Added URL expansion convenience support to `jamf-upload.sh`.
+
+## 2026-03-17
+
+* (#368) Added impact alert notification settings endpoint to the API endpoint list (thanks @neilmartin83).
+
 ## 2026-02-24
 
 * Updated `check_pkg` function in `JamfPackageUploaderBase` to use the Jamf Pro API (v1/packages endpoint) instead of the Classic API.

--- a/JamfUploaderProcessors/JamfAPIClientUploader.py
+++ b/JamfUploaderProcessors/JamfAPIClientUploader.py
@@ -97,6 +97,12 @@ class JamfAPIClientUploader(JamfAPIClientUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "api_client_name": {
             "required": False,
             "description": "Name of the API Client in Jamf",
@@ -117,7 +123,8 @@ class JamfAPIClientUploader(JamfAPIClientUploaderBase):
         },
         "api_role_name": {
             "required": False,
-            "description": "API Role to scope to the API Client. Currently limited to a single API Role",
+            "description": "API Role to scope to the API Client. Currently limited to a single "
+            "API Role",
             "default": "",
         },
         "replace_api_client": {
@@ -161,6 +168,10 @@ class JamfAPIClientUploader(JamfAPIClientUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfAPIRoleUploader.py
+++ b/JamfUploaderProcessors/JamfAPIRoleUploader.py
@@ -97,6 +97,12 @@ class JamfAPIRoleUploader(JamfAPIRoleUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "api_role_name": {
             "required": True,
             "description": "Name of the API role",
@@ -144,6 +150,10 @@ class JamfAPIRoleUploader(JamfAPIRoleUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfAccountUploader.py
+++ b/JamfUploaderProcessors/JamfAccountUploader.py
@@ -95,6 +95,12 @@ class JamfAccountUploader(JamfAccountUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "account_name": {
             "required": True,
             "description": "account name",
@@ -102,7 +108,7 @@ class JamfAccountUploader(JamfAccountUploaderBase):
         },
         "account_type": {
             "required": True,
-            "description": "account type - either 'user' or 'group",
+            "description": "account type - either 'user' or 'group'",
             "default": "user",
         },
         "account_template": {
@@ -160,6 +166,10 @@ class JamfAccountUploader(JamfAccountUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfCategoryUploader.py
+++ b/JamfUploaderProcessors/JamfCategoryUploader.py
@@ -94,6 +94,12 @@ class JamfCategoryUploader(JamfCategoryUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "category_name": {"required": False, "description": "Category", "default": ""},
         "category_priority": {
             "required": False,
@@ -133,6 +139,10 @@ class JamfCategoryUploader(JamfCategoryUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfComputerGroupDeleter.py
+++ b/JamfUploaderProcessors/JamfComputerGroupDeleter.py
@@ -93,6 +93,12 @@ class JamfComputerGroupDeleter(JamfComputerGroupDeleterBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "computergroup_name": {
             "required": True,
             "description": "Computer Group to delete",
@@ -120,6 +126,10 @@ class JamfComputerGroupDeleter(JamfComputerGroupDeleterBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfComputerGroupUploader.py
+++ b/JamfUploaderProcessors/JamfComputerGroupUploader.py
@@ -94,6 +94,12 @@ class JamfComputerGroupUploader(JamfComputerGroupUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "computergroup_name": {
             "required": False,
             "description": "Computer Group name",
@@ -135,6 +141,10 @@ class JamfComputerGroupUploader(JamfComputerGroupUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfComputerPreStageUploader.py
+++ b/JamfUploaderProcessors/JamfComputerPreStageUploader.py
@@ -99,6 +99,12 @@ class JamfComputerPreStageUploader(JamfComputerPreStageUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "prestage_name": {
             "required": False,
             "description": "Name of the object. Required except for settings-related objects.",
@@ -145,6 +151,10 @@ class JamfComputerPreStageUploader(JamfComputerPreStageUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfComputerProfileUploader.py
+++ b/JamfUploaderProcessors/JamfComputerProfileUploader.py
@@ -94,6 +94,12 @@ class JamfComputerProfileUploader(JamfComputerProfileUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "profile_name": {
             "required": False,
             "description": "Configuration Profile name",
@@ -168,6 +174,10 @@ class JamfComputerProfileUploader(JamfComputerProfileUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfComputerStaticGroupUploader.py
+++ b/JamfUploaderProcessors/JamfComputerStaticGroupUploader.py
@@ -96,6 +96,12 @@ class JamfComputerStaticGroupUploader(JamfComputerStaticGroupUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "computergroup_name": {
             "required": False,
             "description": "Computer Group name",
@@ -143,6 +149,10 @@ class JamfComputerStaticGroupUploader(JamfComputerStaticGroupUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfDockItemUploader.py
+++ b/JamfUploaderProcessors/JamfDockItemUploader.py
@@ -94,6 +94,12 @@ class JamfDockItemUploader(JamfDockItemUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "dock_item_name": {
             "required": True,
             "description": "Name of Dock Item",
@@ -142,6 +148,10 @@ class JamfDockItemUploader(JamfDockItemUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
+++ b/JamfUploaderProcessors/JamfExtensionAttributeUploader.py
@@ -94,6 +94,12 @@ class JamfExtensionAttributeUploader(JamfExtensionAttributeUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "ea_name": {
             "required": False,
             "description": "Extension Attribute name",
@@ -178,6 +184,10 @@ class JamfExtensionAttributeUploader(JamfExtensionAttributeUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfIconUploader.py
+++ b/JamfUploaderProcessors/JamfIconUploader.py
@@ -95,6 +95,12 @@ class JamfIconUploader(JamfIconUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "icon_file": {
             "required": False,
             "description": "An icon to upload",
@@ -134,6 +140,10 @@ class JamfIconUploader(JamfIconUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfMSUPlanUploader.py
+++ b/JamfUploaderProcessors/JamfMSUPlanUploader.py
@@ -102,6 +102,12 @@ class JamfMSUPlanUploader(JamfMSUPlanUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "days_until_force_install": {
             "required": False,
             "description": "Days until forced installation of planned managed software update.",
@@ -169,6 +175,10 @@ class JamfMSUPlanUploader(JamfMSUPlanUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfMacAppUploader.py
+++ b/JamfUploaderProcessors/JamfMacAppUploader.py
@@ -99,6 +99,12 @@ class JamfMacAppUploader(JamfMacAppUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "macapp_name": {
             "required": False,
             "description": "Mac App Store app name",
@@ -165,6 +171,10 @@ class JamfMacAppUploader(JamfMacAppUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfMobileDeviceAppUploader.py
+++ b/JamfUploaderProcessors/JamfMobileDeviceAppUploader.py
@@ -99,6 +99,12 @@ class JamfMobileDeviceAppUploader(JamfMobileDeviceAppUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "mobiledeviceapp_name": {
             "required": False,
             "description": "Mobile device app name",
@@ -171,6 +177,10 @@ class JamfMobileDeviceAppUploader(JamfMobileDeviceAppUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfMobileDeviceExtensionAttributeUploader.py
+++ b/JamfUploaderProcessors/JamfMobileDeviceExtensionAttributeUploader.py
@@ -97,6 +97,12 @@ class JamfMobileDeviceExtensionAttributeUploader(
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "ea_name": {
             "required": False,
             "description": "Extension Attribute name",
@@ -167,6 +173,10 @@ class JamfMobileDeviceExtensionAttributeUploader(
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfMobileDeviceGroupUploader.py
+++ b/JamfUploaderProcessors/JamfMobileDeviceGroupUploader.py
@@ -93,6 +93,12 @@ class JamfMobileDeviceGroupUploader(JamfMobileDeviceGroupUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "mobiledevicegroup_name": {
             "required": False,
             "description": "Mobile Device Group name",
@@ -134,6 +140,10 @@ class JamfMobileDeviceGroupUploader(JamfMobileDeviceGroupUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfMobileDeviceProfileUploader.py
+++ b/JamfUploaderProcessors/JamfMobileDeviceProfileUploader.py
@@ -96,6 +96,12 @@ class JamfMobileDeviceProfileUploader(JamfMobileDeviceProfileUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "profile_name": {
             "required": False,
             "description": "Configuration Profile name",
@@ -157,6 +163,10 @@ class JamfMobileDeviceProfileUploader(JamfMobileDeviceProfileUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfMobileDeviceStaticGroupUploader.py
+++ b/JamfUploaderProcessors/JamfMobileDeviceStaticGroupUploader.py
@@ -96,6 +96,12 @@ class JamfMobileDeviceStaticGroupUploader(JamfMobileDeviceStaticGroupUploaderBas
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "mobiledevicegroup_name": {
             "required": False,
             "description": "Mobile Device Group name",
@@ -143,6 +149,10 @@ class JamfMobileDeviceStaticGroupUploader(JamfMobileDeviceStaticGroupUploaderBas
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfObjectDeleter.py
+++ b/JamfUploaderProcessors/JamfObjectDeleter.py
@@ -96,6 +96,12 @@ class JamfObjectDeleter(JamfObjectDeleterBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "object_name": {
             "required": True,
             "description": "Object to delete",
@@ -120,6 +126,10 @@ class JamfObjectDeleter(JamfObjectDeleterBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfObjectStateChanger.py
+++ b/JamfUploaderProcessors/JamfObjectStateChanger.py
@@ -94,6 +94,12 @@ class JamfObjectStateChanger(JamfObjectStateChangerBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "object_name": {
             "required": True,
             "description": "Name of the object. Required.",
@@ -150,6 +156,10 @@ class JamfObjectStateChanger(JamfObjectStateChangerBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfObjectUploader.py
+++ b/JamfUploaderProcessors/JamfObjectUploader.py
@@ -102,6 +102,12 @@ class JamfObjectUploader(JamfObjectUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "object_name": {
             "required": False,
             "description": "Name of the object. Required except for settings-related objects.",
@@ -178,6 +184,10 @@ class JamfObjectUploader(JamfObjectUploaderBase):
         },
         "process_skipped": {
             "description": "Boolean - True if the upload process was skipped due to skip_and_proceed input variable being set to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfPackageCleaner.py
+++ b/JamfUploaderProcessors/JamfPackageCleaner.py
@@ -148,6 +148,10 @@ class JamfPackageCleaner(JamfPackageCleanerBase):
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
         },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
+        },
     }
 
     def main(self):

--- a/JamfUploaderProcessors/JamfPackageRecalculator.py
+++ b/JamfUploaderProcessors/JamfPackageRecalculator.py
@@ -90,6 +90,12 @@ class JamfPackageRecalculator(JamfPackageRecalculatorBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "skip_if": {
             "required": False,
             "description": "Skip the process if the supplied predicate evaluates to True.",
@@ -104,6 +110,10 @@ class JamfPackageRecalculator(JamfPackageRecalculatorBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfPackageUploader.py
+++ b/JamfUploaderProcessors/JamfPackageUploader.py
@@ -104,6 +104,12 @@ class JamfPackageUploader(JamfPackageUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "CLOUD_DP": {
             "required": False,
             "description": (
@@ -305,6 +311,10 @@ class JamfPackageUploader(JamfPackageUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfPackageUploader.py
+++ b/JamfUploaderProcessors/JamfPackageUploader.py
@@ -110,6 +110,11 @@ class JamfPackageUploader(JamfPackageUploaderBase):
             "without making any writes.",
             "default": False,
         },
+        "show_upload_progress": {
+            "required": False,
+            "description": ("Show a curl progress bar during package upload."),
+            "default": False,
+        },
         "CLOUD_DP": {
             "required": False,
             "description": (

--- a/JamfUploaderProcessors/JamfPatchUploader.py
+++ b/JamfUploaderProcessors/JamfPatchUploader.py
@@ -95,6 +95,12 @@ class JamfPatchUploader(JamfPatchUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "pkg_name": {
             "required": False,
             "description": "Name of package which should be used in the patch."
@@ -174,6 +180,10 @@ class JamfPatchUploader(JamfPatchUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfPkgMetadataUploader.py
+++ b/JamfUploaderProcessors/JamfPkgMetadataUploader.py
@@ -98,6 +98,12 @@ class JamfPkgMetadataUploader(JamfPkgMetadataUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "CLOUD_DP": {
             "required": False,
             "description": (
@@ -195,6 +201,10 @@ class JamfPkgMetadataUploader(JamfPkgMetadataUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfPolicyDeleter.py
+++ b/JamfUploaderProcessors/JamfPolicyDeleter.py
@@ -93,6 +93,12 @@ class JamfPolicyDeleter(JamfPolicyDeleterBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "policy_name": {
             "required": True,
             "description": "Policy to delete",
@@ -120,6 +126,10 @@ class JamfPolicyDeleter(JamfPolicyDeleterBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfPolicyLogFlusher.py
+++ b/JamfUploaderProcessors/JamfPolicyLogFlusher.py
@@ -94,6 +94,12 @@ class JamfPolicyLogFlusher(JamfPolicyLogFlusherBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "policy_name": {
             "required": True,
             "description": "Policy whose log is to be flushed",
@@ -126,6 +132,10 @@ class JamfPolicyLogFlusher(JamfPolicyLogFlusherBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfPolicyUploader.py
+++ b/JamfUploaderProcessors/JamfPolicyUploader.py
@@ -95,6 +95,12 @@ class JamfPolicyUploader(JamfPolicyUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "policy_name": {
             "required": False,
             "description": "Policy name",
@@ -160,6 +166,10 @@ class JamfPolicyUploader(JamfPolicyUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfScriptUploader.py
+++ b/JamfUploaderProcessors/JamfScriptUploader.py
@@ -92,6 +92,12 @@ class JamfScriptUploader(JamfScriptUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "script_path": {
             "required": False,
             "description": "Full path to the script to be uploaded",
@@ -205,6 +211,10 @@ class JamfScriptUploader(JamfScriptUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfSoftwareRestrictionUploader.py
+++ b/JamfUploaderProcessors/JamfSoftwareRestrictionUploader.py
@@ -80,6 +80,12 @@ class JamfSoftwareRestrictionUploader(JamfSoftwareRestrictionUploaderBase):
             "Required for Platform API authentication.",
             "default": "",
         },
+        "dry_run": {
+            "required": False,
+            "description": "If True, perform read-only checks and report what would change "
+            "without making any writes.",
+            "default": False,
+        },
         "restriction_name": {
             "required": True,
             "description": "Software Restriction name",
@@ -152,6 +158,10 @@ class JamfSoftwareRestrictionUploader(JamfSoftwareRestrictionUploaderBase):
         "process_skipped": {
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
+        },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
         },
     }
 

--- a/JamfUploaderProcessors/JamfUnusedPackageCleaner.py
+++ b/JamfUploaderProcessors/JamfUnusedPackageCleaner.py
@@ -129,6 +129,10 @@ class JamfUnusedPackageCleaner(JamfUnusedPackageCleanerBase):
             "description": "Boolean - True if the process was skipped due to "
             "skip_if predicate resolved to True.",
         },
+        "dry_run_summary_result": {
+            "description": "Summary of what would have been changed (only set when dry_run "
+            "is True).",
+        },
     }
 
     def main(self):

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAPIClientUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAPIClientUploaderBase.py
@@ -291,6 +291,18 @@ class JamfAPIClientUploaderBase(JamfUploaderBase):
             verbose_level=2,
         )
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} api_client '{object_name}'")
+            self.env["api_client_updated"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "api_client", "name": object_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # post the script
         r = self.upload_object(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAPIRoleUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAPIRoleUploaderBase.py
@@ -195,6 +195,18 @@ class JamfAPIRoleUploaderBase(JamfUploaderBase):
                 )
                 return
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} api_role '{object_name}'")
+            self.env["api_role_updated"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "api_role", "name": object_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the object
         self.upload_object(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
@@ -287,6 +287,18 @@ class JamfAccountUploaderBase(JamfUploaderBase):
                 )
                 return
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} account '{account_name}'")
+            self.env["account_updated"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "account", "name": account_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the account
         self.upload_account(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfCategoryUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfCategoryUploaderBase.py
@@ -199,6 +199,19 @@ class JamfCategoryUploaderBase(JamfUploaderBase):
         else:
             self.output(f"Category '{category_name}' not found: ID {object_id}")
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} category '{category_name}'")
+            self.env["category"] = category_name
+            self.env["category_id"] = object_id or ""
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "category", "name": category_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the category
         category_id = self.upload_category(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupDeleterBase.py
@@ -144,6 +144,15 @@ class JamfComputerGroupDeleterBase(JamfUploaderBase):
 
         if object_id:
             self.output(f"Computer Group '{computergroup_name}' exists: ID {object_id}")
+            if self.env.get("dry_run"):
+                self.output(f"DRY RUN: Would DELETE computer group '{computergroup_name}' (ID {object_id})")
+                self.env["dry_run_summary_result"] = {
+                    "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                    "report_fields": ["action", "type", "name"],
+                    "data": {"action": "DELETE", "type": "computer_group", "name": computergroup_name},
+                }
+                self.env["process_skipped"] = process_skipped
+                return
             self.output(
                 "Deleting existing computer group",
                 verbose_level=1,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupUploaderBase.py
@@ -229,6 +229,18 @@ class JamfComputerGroupUploaderBase(JamfUploaderBase):
                 )
                 return
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} computer group '{computergroup_name}'")
+            self.env["group_uploaded"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "computer_group", "name": computergroup_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the group
         self.upload_computergroup(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerPreStageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerPreStageUploaderBase.py
@@ -258,6 +258,19 @@ class JamfComputerPreStageUploaderBase(JamfUploaderBase):
             with open(template_file, "w", encoding="utf-8") as file:
                 file.write(template_contents)
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} computer_prestage '{prestage_name}'")
+            self.env["prestage_name"] = prestage_name
+            self.env["prestage_updated"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "computer_prestage", "name": prestage_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the object
         self.upload_prestage(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
@@ -448,6 +448,19 @@ class JamfComputerProfileUploaderBase(JamfUploaderBase):
             token=token,
             tenant_id=jamf_platform_gw_tenant_id,
         )
+
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} configuration profile '{mobileconfig_name}'")
+            self.env["profile_updated"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "os_x_configuration_profile", "name": mobileconfig_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         if object_id:
             self.output(
                 f"Configuration Profile '{mobileconfig_name}' already exists: ID {object_id}"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerStaticGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerStaticGroupUploaderBase.py
@@ -231,6 +231,18 @@ class JamfComputerStaticGroupUploaderBase(JamfUploaderBase):
                     api_url, object_id, token, tenant_id=jamf_platform_gw_tenant_id
                 )
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} computer_static_group '{computergroup_name}'")
+            self.env["group_uploaded"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "computer_static_group", "name": computergroup_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the group
         self.upload_object(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfDockItemUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfDockItemUploaderBase.py
@@ -191,6 +191,18 @@ class JamfDockItemUploaderBase(JamfUploaderBase):
                 )
                 return
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} dock_item '{dock_item_name}'")
+            self.env["dock_item_uploaded"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "dock_item", "name": dock_item_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # Upload the dock item
         self.upload_dock_item(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
@@ -270,6 +270,19 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
                 )
                 return
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} extension attribute '{ea_name}'")
+            self.env["extension_attribute"] = ea_name
+            self.env["ea_uploaded"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "computer_extension_attribute", "name": ea_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the EA
         self.upload_ea(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfIconUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfIconUploaderBase.py
@@ -184,6 +184,16 @@ class JamfIconUploaderBase(JamfUploaderBase):
         if not icon_file:
             raise ProcessorError("ERROR: Icon not found")
 
+        if self.env.get("dry_run"):
+            self.output(f"DRY RUN: Would UPLOAD icon '{icon_file}'")
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": "UPLOAD", "type": "icon", "name": str(icon_file)},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the icon
         r = self.upload_icon(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMSUPlanUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMSUPlanUploaderBase.py
@@ -304,6 +304,16 @@ class JamfMSUPlanUploaderBase(JamfUploaderBase):
         # check for an existing object except for settings-related endpoints
         object_type = "managed_software_updates_plans_group_settings"
 
+        if self.env.get("dry_run"):
+            self.output(f"DRY RUN: Would CREATE msu_plan for group '{group_name}'")
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": "CREATE", "type": "msu_plan", "name": group_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the object
         self.upload_object(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
@@ -198,6 +198,18 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
             tenant_id=jamf_platform_gw_tenant_id,
         )
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} mac_application '{macapp_name}'")
+            self.env["macapp_updated"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "mac_application", "name": macapp_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         if object_id:
             self.output(f"MAS app '{macapp_name}' already exists: ID {object_id}")
             if replace_macapp:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceAppUploaderBase.py
@@ -225,6 +225,18 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
             tenant_id=jamf_platform_gw_tenant_id,
         )
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} mobile_device_application '{mobiledeviceapp_name}'")
+            self.env["mobiledeviceapp_updated"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "mobile_device_application", "name": mobiledeviceapp_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         if object_id:
             self.output(
                 f"Mobile device app '{mobiledeviceapp_name}' already exists: ID {object_id}"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceExtensionAttributeUploaderBase.py
@@ -247,6 +247,18 @@ class JamfMobileDeviceExtensionAttributeUploaderBase(JamfUploaderBase):
                 )
                 return
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} mobile_device_extension_attribute '{ea_name}'")
+            self.env["ea_uploaded"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "mobile_device_extension_attribute", "name": ea_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the EA
         self.upload_ea(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceGroupUploaderBase.py
@@ -211,6 +211,18 @@ class JamfMobileDeviceGroupUploaderBase(JamfUploaderBase):
                 )
                 return
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} mobile_device_group '{mobiledevicegroup_name}'")
+            self.env["group_uploaded"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "mobile_device_group", "name": mobiledevicegroup_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the group
         self.upload_mobiledevicegroup(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
@@ -355,6 +355,19 @@ class JamfMobileDeviceProfileUploaderBase(JamfUploaderBase):
             token=token,
             tenant_id=jamf_platform_gw_tenant_id,
         )
+
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} configuration profile '{mobileconfig_name}'")
+            self.env["profile_updated"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "mobile_device_configuration_profile", "name": mobileconfig_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         if object_id:
             self.output(
                 f"Configuration Profile '{mobileconfig_name}' already exists: ID {object_id}"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceStaticGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceStaticGroupUploaderBase.py
@@ -232,6 +232,18 @@ class JamfMobileDeviceStaticGroupUploaderBase(JamfUploaderBase):
                     api_url, object_id, token, tenant_id=jamf_platform_gw_tenant_id
                 )
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} mobile_device_static_group '{mobiledevicegroup_name}'")
+            self.env["group_uploaded"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "mobile_device_static_group", "name": mobiledevicegroup_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the group
         self.upload_object(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectDeleterBase.py
@@ -94,6 +94,15 @@ class JamfObjectDeleterBase(JamfUploaderBase):
 
         # cloud_distribution_point endpoint doesn't use IDs or names
         if object_type == "cloud_distribution_point":
+            if self.env.get("dry_run"):
+                self.output(f"DRY RUN: Would DELETE singleton {object_type}")
+                self.env["dry_run_summary_result"] = {
+                    "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                    "report_fields": ["action", "type", "name"],
+                    "data": {"action": "DELETE", "type": object_type, "name": object_type},
+                }
+                self.env["process_skipped"] = process_skipped
+                return
             self.output(
                 f"Deleting singleton {object_type} on {api_url}",
                 verbose_level=1,
@@ -126,6 +135,15 @@ class JamfObjectDeleterBase(JamfUploaderBase):
 
             if object_id:
                 self.output(f"{object_type} '{object_name}' exists: ID {object_id}")
+                if self.env.get("dry_run"):
+                    self.output(f"DRY RUN: Would DELETE {object_type} '{object_name}' (ID {object_id})")
+                    self.env["dry_run_summary_result"] = {
+                        "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                        "report_fields": ["action", "type", "name"],
+                        "data": {"action": "DELETE", "type": object_type, "name": object_name},
+                    }
+                    self.env["process_skipped"] = process_skipped
+                    return
                 self.output(
                     f"Deleting existing {object_type}",
                     verbose_level=1,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectStateChangerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectStateChangerBase.py
@@ -286,6 +286,15 @@ class JamfObjectStateChangerBase(JamfUploaderBase):
 
         if object_id:
             self.output(f"{object_type} '{object_name}' exists: ID {object_id}")
+            if self.env.get("dry_run"):
+                self.output(f"DRY RUN: Would STATE_CHANGE {object_type} '{object_name}' to {object_state}")
+                self.env["dry_run_summary_result"] = {
+                    "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                    "report_fields": ["action", "type", "name"],
+                    "data": {"action": "STATE_CHANGE", "type": object_type, "name": object_name},
+                }
+                self.env["process_skipped"] = process_skipped
+                return
             self.output(
                 f"Setting object state to {object_state}",
                 verbose_level=1,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
@@ -370,6 +370,20 @@ class JamfObjectUploaderBase(JamfUploaderBase):
                 namekey_path=namekey_path,
             )
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} {object_type} '{object_name}'")
+            self.env["object_name"] = str(object_name)
+            self.env["object_type"] = object_type
+            self.env["object_updated"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": object_type, "name": str(object_name)},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the object
         self.upload_object(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
@@ -296,6 +296,15 @@ class JamfPackageCleanerBase(JamfUploaderBase):
                 "Use '-vv' to see detailed information. "
                 "Aborting."
             )
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {
+                    "action": "DELETE",
+                    "type": "package",
+                    "name": f"{len(packages_to_delete)} package(s) matching criteria",
+                },
+            }
             return
 
         for package in packages_to_delete:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageRecalculatorBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageRecalculatorBase.py
@@ -149,6 +149,16 @@ class JamfPackageRecalculatorBase(JamfUploaderBase):
                 )
             )
 
+            if self.env.get("dry_run"):
+                self.output("DRY RUN: Would recalculate package inventory on Cloud Distribution Point")
+                self.env["dry_run_summary_result"] = {
+                    "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                    "report_fields": ["action", "type", "name"],
+                    "data": {"action": "RECALCULATE", "type": "cloud_dp_inventory", "name": "packages"},
+                }
+                self.env["process_skipped"] = process_skipped
+                return
+
             # now send the recalculation request
             packages_recalculated = self.recalculate_packages(
                 api_url, token, tenant_id=jamf_platform_gw_tenant_id

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
@@ -752,6 +752,27 @@ class JamfPackageUploaderBase(JamfUploaderBase):
             pkg_id = 0
         self.output(f"Package ID: {object_id}", verbose_level=3)  # TEMP
 
+        if self.env.get("dry_run"):
+            if object_id:
+                action = "UPDATE metadata for"
+            else:
+                action = "CREATE"
+            self.output(f"DRY RUN: Would {action} package '{pkg_name}'")
+            self.env["pkg_name"] = pkg_name
+            self.env["pkg_uploaded"] = False
+            self.env["pkg_metadata_updated"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {
+                    "action": action,
+                    "type": "package",
+                    "name": pkg_name,
+                },
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # Process for SMB shares if defined
         self.output(
             "Number of File Share DPs: " + str(len(smb_shares)), verbose_level=2

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
@@ -465,6 +465,18 @@ class JamfPatchUploaderBase(JamfUploaderBase):
                     )
                     return
 
+            if self.env.get("dry_run"):
+                action = "CREATE" if not patch_id else "UPDATE"
+                self.output(f"DRY RUN: Would {action} patch_policy '{patch_name}'")
+                self.env["patch_updated"] = False
+                self.env["dry_run_summary_result"] = {
+                    "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                    "report_fields": ["action", "type", "name"],
+                    "data": {"action": action, "type": "patch_policy", "name": patch_name},
+                }
+                self.env["process_skipped"] = process_skipped
+                return
+
             # Upload the patch
             r = self.upload_patch(
                 api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPkgMetadataUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPkgMetadataUploaderBase.py
@@ -303,6 +303,19 @@ class JamfPkgMetadataUploaderBase(JamfUploaderBase):
             self.output(f"Package '{pkg_name}' not found on server")
             pkg_id = 0
 
+        if self.env.get("dry_run"):
+            action = "UPDATE metadata for" if int(pkg_id) > 0 else "CREATE"
+            self.output(f"DRY RUN: Would {action} package '{pkg_name}'")
+            self.env["pkg_name"] = pkg_name
+            self.env["pkg_metadata_updated"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "package", "name": pkg_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # now process the package metadata
         if int(pkg_id) > 0:
             # replace existing package metadata

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyDeleterBase.py
@@ -140,6 +140,15 @@ class JamfPolicyDeleterBase(JamfUploaderBase):
 
         if object_id:
             self.output(f"Policy '{policy_name}' exists: ID {object_id}")
+            if self.env.get("dry_run"):
+                self.output(f"DRY RUN: Would DELETE policy '{policy_name}' (ID {object_id})")
+                self.env["dry_run_summary_result"] = {
+                    "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                    "report_fields": ["action", "type", "name"],
+                    "data": {"action": "DELETE", "type": "policy", "name": policy_name},
+                }
+                self.env["process_skipped"] = process_skipped
+                return
             self.output(
                 "Deleting existing policy",
                 verbose_level=1,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyLogFlusherBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyLogFlusherBase.py
@@ -154,6 +154,15 @@ class JamfPolicyLogFlusherBase(JamfUploaderBase):
 
         if object_id:
             self.output(f"Policy '{policy_name}' exists: ID {object_id}")
+            if self.env.get("dry_run"):
+                self.output(f"DRY RUN: Would flush policy log for '{policy_name}'")
+                self.env["dry_run_summary_result"] = {
+                    "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                    "report_fields": ["action", "type", "name"],
+                    "data": {"action": "FLUSH", "type": "policy_log", "name": policy_name},
+                }
+                self.env["process_skipped"] = process_skipped
+                return
             self.output(
                 "Flushing existing policy",
                 verbose_level=1,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
@@ -330,6 +330,20 @@ class JamfPolicyUploaderBase(JamfUploaderBase):
                 )
                 return
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} policy '{policy_name}'")
+            self.env["policy_name"] = policy_name
+            self.env["policy_updated"] = False
+            self.env["changed_policy_id"] = ""
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "policy", "name": policy_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # upload the policy
         r = self.upload_policy(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
@@ -302,6 +302,19 @@ class JamfScriptUploaderBase(JamfUploaderBase):
                 )
                 return
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} script '{script_name}'")
+            self.env["script_name"] = script_name
+            self.env["script_uploaded"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "script", "name": script_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         # post the script
         self.upload_script(
             api_url,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
@@ -250,6 +250,18 @@ class JamfSoftwareRestrictionUploaderBase(JamfUploaderBase):
                 f"Software Restriction '{restriction_name}' not found - will create"
             )
 
+        if self.env.get("dry_run"):
+            action = "CREATE" if not object_id else "UPDATE"
+            self.output(f"DRY RUN: Would {action} restricted_software '{restriction_name}'")
+            self.env["restriction_uploaded"] = False
+            self.env["dry_run_summary_result"] = {
+                "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                "report_fields": ["action", "type", "name"],
+                "data": {"action": action, "type": "restricted_software", "name": restriction_name},
+            }
+            self.env["process_skipped"] = process_skipped
+            return
+
         self.upload_restriction(
             api_url,
             object_name=restriction_name,

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUnusedPackageCleanerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUnusedPackageCleanerBase.py
@@ -549,6 +549,15 @@ class JamfUnusedPackageCleanerBase(JamfUploaderBase):
                     "Dry run mode enabled. No packages will be deleted.",
                     verbose_level=1,
                 )
+                self.env["dry_run_summary_result"] = {
+                    "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
+                    "report_fields": ["action", "type", "name"],
+                    "data": {
+                        "action": "DELETE",
+                        "type": "package",
+                        "name": f"{len(unused_packages)} unused package(s)",
+                    },
+                }
             else:
                 # delete the packages
                 for pkg_id, pkg_name in unused_packages.items():

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -1332,6 +1332,16 @@ class JamfUploaderBase(Processor):
         The Jamf Platform API uses OAuth 2.0 for authentication.
         """
         tmp_dir = self.make_tmp_dir(jamf_url=url)
+
+        # dry-run: skip write operations but allow auth/token requests
+        if self.env.get("dry_run") and request in ("POST", "PUT", "PATCH", "DELETE"):
+            if endpoint_type not in ("oauth", "token", "auth", "platform_api_token"):
+                self.output(f"DRY RUN: Would {request} to {url}")
+                r = namedtuple(
+                    "r", ["headers", "status_code", "output"], defaults=(None, None, None)
+                )
+                return r(headers=[], status_code=200, output={})
+
         headers_file = os.path.join(tmp_dir, "curl_headers_from_jamf_upload.txt")
         output_file = self.init_temp_file(url, suffix=".txt")
         cookie_jar = os.path.join(tmp_dir, "curl_cookies_from_jamf_upload.txt")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -55,7 +55,7 @@ class JamfUploaderBase(Processor):
     """Common functions used by at least two JamfUploader processors."""
 
     # Global version
-    __version__ = "2026.05.04.0"
+    __version__ = "2026.05.29.0"
 
     # Schema registry instance — lazily initialised per processor run
     _registry = None
@@ -1339,7 +1339,9 @@ class JamfUploaderBase(Processor):
             if endpoint_type not in ("oauth", "token", "auth", "platform_api_token"):
                 self.output(f"DRY RUN: Would {request} to {url}")
                 r = namedtuple(
-                    "r", ["headers", "status_code", "output"], defaults=(None, None, None)
+                    "r",
+                    ["headers", "status_code", "output"],
+                    defaults=(None, None, None),
                 )
                 return r(headers=[], status_code=200, output={})
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -1417,8 +1417,8 @@ class JamfUploaderBase(Processor):
             # all endpoints can be specified with show-error
             curl_cmd.extend(["--show-error"])
 
-            # we want to be silent except for package uploads
-            if endpoint_type != "package_v1":
+            # we want to be silent except for package uploads with progress enabled
+            if endpoint_type != "package_v1" or not self.env.get("show_upload_progress"):
                 curl_cmd.extend(["--silent"])
 
             # icon download
@@ -1437,7 +1437,8 @@ class JamfUploaderBase(Processor):
 
             # package upload (Jamf Pro API)
             elif endpoint_type == "package_v1":
-                curl_cmd.extend(["--progress-bar"])
+                if self.env.get("show_upload_progress"):
+                    curl_cmd.extend(["--progress-bar"])
                 curl_cmd.extend(["--header", "Content-type: multipart/form-data"])
                 curl_cmd.extend(["--form", f"file=@{data}"])
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -598,6 +598,7 @@ class JamfUploaderBase(Processor):
             request="POST",
             url=url,
             enc_creds=enc_creds,
+            endpoint_type="token",
         )
         output = r.output
         if r.status_code == 200:

--- a/JamfUploaderProcessors/READMEs/JamfAPIClientUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfAPIClientUploader.md
@@ -50,6 +50,10 @@ A processor for AutoPkg that will create or amend an API Client to a Jamf Pro se
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfAPIRoleUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfAPIRoleUploader.md
@@ -39,6 +39,10 @@ A processor for AutoPkg that will create or amend an API Role to a Jamf Pro serv
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfAccountUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfAccountUploader.md
@@ -42,6 +42,10 @@ A processor for AutoPkg that will upload an account to a Jamf Cloud or on-prem s
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfCategoryUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfCategoryUploader.md
@@ -40,6 +40,10 @@ A processor for AutoPkg that will upload a category to a Jamf Cloud or on-prem s
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfComputerGroupDeleter.md
+++ b/JamfUploaderProcessors/READMEs/JamfComputerGroupDeleter.md
@@ -28,6 +28,10 @@ A processor for AutoPkg that will delete a computer group from a Jamf Cloud or o
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfComputerGroupUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfComputerGroupUploader.md
@@ -39,6 +39,10 @@ A processor for AutoPkg that will upload a computer group (smart or static) to a
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfComputerProfileUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfComputerProfileUploader.md
@@ -68,6 +68,10 @@ A processor for AutoPkg that will upload a computer configuration profile to a J
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfComputerStaticGroupUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfComputerStaticGroupUploader.md
@@ -43,6 +43,10 @@ A processor for AutoPkg that will upload a static computer group to a Jamf Cloud
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfDockItemUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfDockItemUploader.md
@@ -42,6 +42,10 @@ A processor for AutoPkg that will upload a Dock item to a Jamf Cloud or on-prem 
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfExtensionAttributeUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfExtensionAttributeUploader.md
@@ -67,6 +67,10 @@ A processor for AutoPkg that will upload an Extension Attribute item to a Jamf C
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfMSUPlanUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMSUPlanUploader.md
@@ -42,6 +42,10 @@ A processor for AutoPkg that will create a Managed Software Update Plan. Current
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfMacAppUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMacAppUploader.md
@@ -48,6 +48,10 @@ A processor for AutoPkg that will update or clone a Mac App Store app object on 
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfMobileDeviceAppUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMobileDeviceAppUploader.md
@@ -51,6 +51,10 @@ A processor for AutoPkg that will update or clone a Mobile Device app object on 
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfMobileDeviceExtensionAttributeUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMobileDeviceExtensionAttributeUploader.md
@@ -57,6 +57,10 @@ A processor for AutoPkg that will upload a Mobile Device Extension Attribute ite
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfMobileDeviceGroupUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMobileDeviceGroupUploader.md
@@ -39,6 +39,10 @@ A processor for AutoPkg that will upload a mobile device group (smart or static)
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfMobileDeviceProfileUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMobileDeviceProfileUploader.md
@@ -61,6 +61,10 @@ A processor for AutoPkg that will upload a mobile device configuration profile t
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfMobileDeviceStaticGroupUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMobileDeviceStaticGroupUploader.md
@@ -43,6 +43,10 @@ A processor for AutoPkg that will upload a static mobile device group to a Jamf 
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfObjectDeleter.md
+++ b/JamfUploaderProcessors/READMEs/JamfObjectDeleter.md
@@ -27,6 +27,10 @@ A processor for AutoPkg to delete an API object.
 - **object_type**:
   - **required**: True
   - **description**: The API object type. This is in the singular form - the name of the key in the XML template. See the [Object Reference](./Object%20Reference.md) for valid objects.
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfObjectStateChanger.md
+++ b/JamfUploaderProcessors/READMEs/JamfObjectStateChanger.md
@@ -36,6 +36,10 @@ A processor for AutoPkg that will change the state of an object on a Jamf Cloud 
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfObjectUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfObjectUploader.md
@@ -45,6 +45,10 @@ A processor for AutoPkg that will upload various Classic API or Jamf Pro API obj
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfPackageRecalculator.md
+++ b/JamfUploaderProcessors/READMEs/JamfPackageRecalculator.md
@@ -21,6 +21,10 @@ A processor for AutoPkg that will recalculate the cloud ditribution point invent
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfPackageUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfPackageUploader.md
@@ -111,6 +111,10 @@ Can be run as a post-processor for a pkg recipe or in a child recipe. The parent
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfPatchUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfPatchUploader.md
@@ -46,6 +46,10 @@ A processor for AutoPkg that will upload a Patch Policy to a Jamf Cloud or on-pr
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfPolicyDeleter.md
+++ b/JamfUploaderProcessors/READMEs/JamfPolicyDeleter.md
@@ -28,6 +28,10 @@ A processor for AutoPkg that will delete a policy from a Jamf Cloud or on-prem s
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfPolicyLogFlusher.md
+++ b/JamfUploaderProcessors/READMEs/JamfPolicyLogFlusher.md
@@ -32,6 +32,10 @@ A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfPolicyUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfPolicyUploader.md
@@ -50,6 +50,10 @@ A processor for AutoPkg that will upload a policy to a Jamf Cloud or on-prem ser
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfScriptUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfScriptUploader.md
@@ -83,6 +83,10 @@ A processor for AutoPkg that will upload a script to a Jamf Cloud or on-prem ser
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/JamfUploaderProcessors/READMEs/JamfSoftwareRestrictionUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfSoftwareRestrictionUploader.md
@@ -64,6 +64,10 @@ A processor for AutoPkg that will upload a restricted software record to a Jamf 
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+- **dry_run:**
+  - **required:** False
+  - **description:** If True, perform read-only checks and report what would change without making any writes.
+  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -64,6 +64,9 @@ while [[ "$#" -gt 0 ]]; do
     -v*)
         verbosity="$1"
     ;;
+    --dry-run)
+        dry_run=1
+    ;;
     -h | --help)
         echo "Usage: test.sh -t|--test TEST_TYPE [-u|--url JAMF_URL] [-v VERBOSITY]"
         echo "Available TEST_TYPE values:"
@@ -256,6 +259,12 @@ fi
 if [[ $client_id ]]; then
     command_base+=(
         --clientid "$client_id"
+    )
+fi
+
+if [[ $dry_run ]]; then
+    command_base+=(
+        --dry-run
     )
 fi
 

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -1110,6 +1110,7 @@ pkg)
         --info "Uploaded directly by JamfPackageUploader using v1/packages"
         --notes "$(date)"
         --replace
+        --progress
     )
 ;;
 pkg-plus-calc*)
@@ -1122,6 +1123,7 @@ pkg-plus-calc*)
         --notes "$(date)"
         --recalculate
         --replace
+        --progress
     )
 ;;
 dock)
@@ -1193,6 +1195,7 @@ pkg-noreplace)
         --category JamfUploadTest
         --info "Uploaded directly by JamfPackageUploader using v1/packages"
         --notes "$(date)"
+        --progress
     )
 ;;
 pkg-aws)

--- a/jamf-upload.sh
+++ b/jamf-upload.sh
@@ -264,6 +264,7 @@ Package Upload arguments:
                             Only applicable if --recalculate is set.
     --md5                   Use MD5 hash instead of SHA512. Required for packages 
                             to be installable via MDM InstallEnterpriseApplication
+    --progress              Show a curl progress bar during package upload.
 
 Package Metadata Upload arguments:
     --name <string>         The package display name
@@ -1506,26 +1507,6 @@ while test $# -gt 0; do
             fi
         fi
         ;;
-    --pkg | --pkg_path | --pkg-path)
-        shift
-        if [[ $processor == "JamfPackageUploader" ]]; then
-            if plutil -replace pkg_path -string "$1" "$temp_processor_plist"; then
-                echo "   [jamf-upload] Wrote pkg_path='$1' into $temp_processor_plist"
-            fi
-        elif [[ $processor == "JamfPkgMetadataUploader" ]]; then
-            if plutil -replace pkg_name -string "$1" "$temp_processor_plist"; then
-                echo "   [jamf-upload] Wrote pkg_name='$1' into $temp_processor_plist"
-            fi
-        fi
-        ;;
-    --pkg-name | --pkg_name)
-        shift
-        if [[ $processor == "JamfPackageUploader" || $processor == "JamfPatchChecker" || $processor == "JamfPatchUploader" || $processor == "JamfPkgMetadataUploader" || $processor == "JamfUploaderJiraIssueCreator" || $processor == "JamfUploaderSlacker" || $processor == "JamfUploaderTeamsNotifier" ]]; then
-            if plutil -replace pkg_name -string "$1" "$temp_processor_plist"; then
-                echo "   [jamf-upload] Wrote pkg_name='$1' into $temp_processor_plist"
-            fi
-        fi
-        ;;
     --info)
         shift
         if [[ $processor == "JamfPackageUploader" || $processor == "JamfPkgMetadataUploader" ]]; then
@@ -1547,6 +1528,33 @@ while test $# -gt 0; do
         elif [[ $processor == "JamfScriptUploader" ]]; then
             if plutil -replace script_notes -string "$1" "$temp_processor_plist"; then
                 echo "   [jamf-upload] Wrote script_notes='$1' into $temp_processor_plist"
+            fi
+        fi
+        ;;
+    --pkg | --pkg_path | --pkg-path)
+        shift
+        if [[ $processor == "JamfPackageUploader" ]]; then
+            if plutil -replace pkg_path -string "$1" "$temp_processor_plist"; then
+                echo "   [jamf-upload] Wrote pkg_path='$1' into $temp_processor_plist"
+            fi
+        elif [[ $processor == "JamfPkgMetadataUploader" ]]; then
+            if plutil -replace pkg_name -string "$1" "$temp_processor_plist"; then
+                echo "   [jamf-upload] Wrote pkg_name='$1' into $temp_processor_plist"
+            fi
+        fi
+        ;;
+    --pkg-name | --pkg_name)
+        shift
+        if [[ $processor == "JamfPackageUploader" || $processor == "JamfPatchChecker" || $processor == "JamfPatchUploader" || $processor == "JamfPkgMetadataUploader" || $processor == "JamfUploaderJiraIssueCreator" || $processor == "JamfUploaderSlacker" || $processor == "JamfUploaderTeamsNotifier" ]]; then
+            if plutil -replace pkg_name -string "$1" "$temp_processor_plist"; then
+                echo "   [jamf-upload] Wrote pkg_name='$1' into $temp_processor_plist"
+            fi
+        fi
+        ;;
+    --progress)
+        if [[ $processor == "JamfPackageUploader" ]]; then
+            if plutil -replace show_upload_progress -string "True" "$temp_processor_plist"; then
+                echo "   [jamf-upload] Wrote show_upload_progress='True' into $temp_processor_plist"
             fi
         fi
         ;;

--- a/jamf-upload.sh
+++ b/jamf-upload.sh
@@ -70,6 +70,8 @@ Arguments:
                             A Jamf CLI profile to use to obtain a bearer token
     --recipe-dir <RECIPE_DIR>
                             The directory containing the AutoPkg recipes
+    --dry-run               Run the processor in dry run mode. No changes will be made to the Jamf Pro server. 
+                            Works with all processors.
 
 UPLOAD OPTIONS
 
@@ -815,6 +817,11 @@ while test $# -gt 0; do
             echo "   [jamf-upload] Wrote skip_if='$1' into $temp_processor_plist"
         fi
         ;;
+    --dry-run)
+        if plutil -replace dry_run -string "True" "$temp_processor_plist"; then
+            echo "   [jamf-upload] Wrote dry_run='True' into $temp_processor_plist"
+        fi
+        ;;
     --type)
         shift
         if [[ $processor == "JamfAccountUploader" ]]; then
@@ -1462,13 +1469,6 @@ while test $# -gt 0; do
         if [[ $processor == "JamfObjectStateChanger" ]]; then
             if plutil -replace retain_data -string "$1" "$temp_processor_plist"; then
                 echo "   [jamf-upload] Wrote retain_data='$1' into $temp_processor_plist"
-            fi
-        fi
-        ;;
-    --dry-run)
-        if [[ $processor == "JamfPackageCleaner" || $processor == "JamfUnusedPackageCleaner" ]]; then
-            if plutil -replace dry_run -string "True" "$temp_processor_plist"; then
-                echo "   [jamf-upload] Wrote dry_run='True' into $temp_processor_plist"
             fi
         fi
         ;;


### PR DESCRIPTION
Introduce a dry_run option to allow users to preview changes without making actual modifications. This provides a summary of potential changes.