### PR TITLE
Fix dry run summary handling

### DIFF
--- a/JamfUploaderProcessors/JamfMobileDeviceGroupUploader.py
+++ b/JamfUploaderProcessors/JamfMobileDeviceGroupUploader.py
@@ -134,7 +134,7 @@ class JamfMobileDeviceGroupUploader(JamfMobileDeviceGroupUploaderBase):
     }
 
     output_variables = {
-        "JamfMobileDeviceGroupUploader_summary_result": {
+        "jamfmobiledevicegroupuploader_summary_result": {
             "description": "Description of interesting results.",
         },
         "process_skipped": {

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAPIClientUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAPIClientUploaderBase.py
@@ -185,6 +185,8 @@ class JamfAPIClientUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfapiclientuploader_summary_result" in self.env:
             del self.env["jamfapiclientuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAPIRoleUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAPIRoleUploaderBase.py
@@ -119,6 +119,8 @@ class JamfAPIRoleUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfapiroleuploader_summary_result" in self.env:
             del self.env["jamfapiroleuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
@@ -185,6 +185,8 @@ class JamfAccountUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfaccountuploader_summary_result" in self.env:
             del self.env["jamfaccountuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfCategoryUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfCategoryUploaderBase.py
@@ -133,6 +133,8 @@ class JamfCategoryUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfcategoryuploader_summary_result" in self.env:
             del self.env["jamfcategoryuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupDeleterBase.py
@@ -97,6 +97,8 @@ class JamfComputerGroupDeleterBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfcomputergroupdeleter_summary_result" in self.env:
             del self.env["jamfcomputergroupdeleter_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupUploaderBase.py
@@ -151,6 +151,8 @@ class JamfComputerGroupUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfcomputergroupuploader_summary_result" in self.env:
             del self.env["jamfcomputergroupuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerPreStageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerPreStageUploaderBase.py
@@ -127,6 +127,8 @@ class JamfComputerPreStageUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfcomputerprestageuploader_summary_result" in self.env:
             del self.env["jamfcomputerprestageuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
@@ -296,6 +296,8 @@ class JamfComputerProfileUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfcomputerprofileuploader_summary_result" in self.env:
             del self.env["jamfcomputerprofileuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerStaticGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerStaticGroupUploaderBase.py
@@ -157,6 +157,8 @@ class JamfComputerStaticGroupUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfcomputerstaticgroupuploader_summary_result" in self.env:
             del self.env["jamfcomputerstaticgroupuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfDockItemUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfDockItemUploaderBase.py
@@ -132,6 +132,8 @@ class JamfDockItemUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfdockitemuploader_summary_result" in self.env:
             del self.env["jamfdockitemuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
@@ -192,6 +192,8 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfextensionattributeuploader_summary_result" in self.env:
             del self.env["jamfextensionattributeuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfIconUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfIconUploaderBase.py
@@ -143,6 +143,8 @@ class JamfIconUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamficonuploader_summary_result" in self.env:
             del self.env["jamficonuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMSUPlanUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMSUPlanUploaderBase.py
@@ -212,6 +212,8 @@ class JamfMSUPlanUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfmsuplanuploader_summary_result" in self.env:
             del self.env["jamfmsuplanuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
@@ -143,6 +143,8 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfmacappuploader_summary_result" in self.env:
             del self.env["jamfmacappuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceAppUploaderBase.py
@@ -169,6 +169,8 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfmobiledeviceappuploader_summary_result" in self.env:
             del self.env["jamfmobiledeviceappuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceExtensionAttributeUploaderBase.py
@@ -180,6 +180,8 @@ class JamfMobileDeviceExtensionAttributeUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfmobiledeviceextensionattributeuploader_summary_result" in self.env:
             del self.env["jamfmobiledeviceextensionattributeuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceGroupUploaderBase.py
@@ -132,8 +132,10 @@ class JamfMobileDeviceGroupUploaderBase(JamfUploaderBase):
             max_tries = 5
 
         # clear any pre-existing summary result
-        if "JamfMobileDeviceGroupUploader_summary_result" in self.env:
-            del self.env["JamfMobileDeviceGroupUploader_summary_result"]
+        if "jamfmobiledevicegroupuploader_summary_result" in self.env:
+            del self.env["jamfmobiledevicegroupuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 
@@ -242,7 +244,7 @@ class JamfMobileDeviceGroupUploaderBase(JamfUploaderBase):
         # output the summary
         self.env["group_uploaded"] = group_uploaded
         if group_uploaded:
-            self.env["JamfMobileDeviceGroupUploader_summary_result"] = {
+            self.env["jamfmobiledevicegroupuploader_summary_result"] = {
                 "summary_text": (
                     "The following Mobile Device Groups were created or updated "
                     "in Jamf Pro:"

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
@@ -240,6 +240,8 @@ class JamfMobileDeviceProfileUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfmobiledeviceprofileuploader_summary_result" in self.env:
             del self.env["jamfmobiledeviceprofileuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceStaticGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceStaticGroupUploaderBase.py
@@ -158,6 +158,8 @@ class JamfMobileDeviceStaticGroupUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfmobiledevicestaticgroupuploader_summary_result" in self.env:
             del self.env["jamfmobiledevicestaticgroupuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectDeleterBase.py
@@ -55,6 +55,8 @@ class JamfObjectDeleterBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfobjectdeleter_summary_result" in self.env:
             del self.env["jamfobjectdeleter_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -573,11 +573,12 @@ class JamfObjectReaderBase(JamfUploaderBase):
             self.env["parsed_object"] = str(parsed_object)
 
         # output the summary
-        self.env["jamfobjectreader_summary_result"] = {
-            "summary_text": "The following objects were outputted in Jamf Pro:",
-            "report_fields": ["file_path"],
-            "data": {
-                "file_path": file_path,
-            },
-        }
+        if file_path:
+            self.env["jamfobjectreader_summary_result"] = {
+                "summary_text": "The following objects were outputted in Jamf Pro:",
+                "report_fields": ["file_path"],
+                "data": {
+                    "file_path": file_path,
+                },
+            }
         self.env["process_skipped"] = process_skipped

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectStateChangerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectStateChangerBase.py
@@ -230,6 +230,8 @@ class JamfObjectStateChangerBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfobjectstatechanger_summary_result" in self.env:
             del self.env["jamfobjectstatechanger_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
@@ -196,6 +196,8 @@ class JamfObjectUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfobjectuploader_summary_result" in self.env:
             del self.env["jamfobjectuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         # skip the process if skip_if is True
         if skip_if and self.predicate_evaluates_as_true(skip_if):

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
@@ -201,6 +201,8 @@ class JamfPackageCleanerBase(JamfUploaderBase):
         # Clear any pre-existing summary result
         if "jamfpackagecleaner_summary_result" in self.env:
             del self.env["jamfpackagecleaner_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         # Abort if the package name match string is too short
         if len(pkg_name_match) < minimum_name_length:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageRecalculatorBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageRecalculatorBase.py
@@ -126,6 +126,8 @@ class JamfPackageRecalculatorBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfpackagerecalculator_summary_result" in self.env:
             del self.env["jamfpackagerecalculator_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         # recalculate packages on Cloud Distribution Point if the metadata was updated and recalculation requested
         # (only works on Jamf Pro 11.10 or newer)

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
@@ -671,6 +671,8 @@ class JamfPackageUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfpackageuploader_summary_result" in self.env:
             del self.env["jamfpackageuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         # See if the package is a bundle (directory).
         # If so, zip_pkg_path will look for an existing .zip

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
@@ -288,6 +288,8 @@ class JamfPatchUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfpatchuploader_summary_result" in self.env:
             del self.env["jamfpatchuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPkgMetadataUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPkgMetadataUploaderBase.py
@@ -235,6 +235,8 @@ class JamfPkgMetadataUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfpkgmetadatauploader_summary_result" in self.env:
             del self.env["jamfpkgmetadatauploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyDeleterBase.py
@@ -93,6 +93,8 @@ class JamfPolicyDeleterBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfpolicydeleter_summary_result" in self.env:
             del self.env["jamfpolicydeleter_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyLogFlusherBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyLogFlusherBase.py
@@ -107,6 +107,8 @@ class JamfPolicyLogFlusherBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfpolicylogflusher_summary_result" in self.env:
             del self.env["jamfpolicylogflusher_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
@@ -247,6 +247,8 @@ class JamfPolicyUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfpolicyuploader_summary_result" in self.env:
             del self.env["jamfpolicyuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
@@ -196,6 +196,8 @@ class JamfScriptUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfscriptuploader_summary_result" in self.env:
             del self.env["jamfscriptuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
@@ -166,6 +166,8 @@ class JamfSoftwareRestrictionUploaderBase(JamfUploaderBase):
         # clear any pre-existing summary result
         if "jamfsoftwarerestrictionuploader_summary_result" in self.env:
             del self.env["jamfsoftwarerestrictionuploader_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUnusedPackageCleanerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUnusedPackageCleanerBase.py
@@ -405,6 +405,8 @@ class JamfUnusedPackageCleanerBase(JamfUploaderBase):
         # Clear any pre-existing summary result
         if "jamfunusedpackagecleaner_summary_result" in self.env:
             del self.env["jamfunusedpackagecleaner_summary_result"]
+        if "dry_run_summary_result" in self.env:
+            del self.env["dry_run_summary_result"]
 
         # Get all packages from Jamf Pro as JSON object
         self.output(f"Getting all packages from {jamf_url}")

--- a/JamfUploaderProcessors/READMEs/JamfMobileDeviceGroupUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMobileDeviceGroupUploader.md
@@ -49,5 +49,5 @@ A processor for AutoPkg that will upload a mobile device group (smart or static)
 
 ## Output variables
 
-- **jamfmobiledeviceuploader_summary_result:**
+- **jamfmobiledevicegroupuploader_summary_result:**
   - **description:** Description of interesting results.


### PR DESCRIPTION
Flush the summary output for dry runs to ensure that any pre-existing dry run summary results are cleared during execution. Update the summary result variable name for the mobile device group uploader.