### PR TITLE
Add pagination to JamfPackageCleaner

### DIFF
--- a/JamfUploaderProcessors/CHANGELOG.md
+++ b/JamfUploaderProcessors/CHANGELOG.md
@@ -6,6 +6,7 @@ The dates here represent when the features were added to the processors in the `
 
 * Added `dry_run` option to all processors. When set to `True`, processors perform read-only checks and report what would change without making any writes to the Jamf Pro server.
 * Made the curl progress bar during package upload optional via the `show_upload_progress` input parameter in `JamfPackageUploader`. Progress output is now disabled by default to avoid interfering with logging systems.
+* Fixed `JamfPackageCleaner` to use paginated requests when retrieving the package list from the Jamf Pro API, ensuring all packages are returned on large servers.
 
 ## 2026-05-08
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
@@ -17,7 +17,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import json
 import os.path
 import sys
 
@@ -240,11 +239,14 @@ class JamfPackageCleanerBase(JamfUploaderBase):
         # check for existing
         object_type = "package_v1"
         url = f"{api_url}/{self.api_endpoints(object_type, tenant_id=jamf_platform_gw_tenant_id)}"
-        r = self.curl(api_type="jpapi", request="GET", url=url, token=token)
-        if isinstance(r.output, dict):
-            jamf_packages = r.output["results"]
-        else:
-            jamf_packages = json.loads(r.output)["results"]
+        jamf_packages = self.paginated_get(
+            api_type="jpapi",
+            url=url,
+            token=token,
+            object_type=object_type,
+            namekey="packageName",
+            domain=api_url,
+        )
 
         # Find packages that match the name pattern
         found_packages = [

--- a/_tests/test.sh
+++ b/_tests/test.sh
@@ -1217,7 +1217,7 @@ pkgclean)
         "${command_base[@]}"
         pkgclean
         --keep "0"
-        --key "NAME=gen-pkg-lightspeed"
+        --name "pkg-nfrgrahampugh-branding-desktop"
     )
 ;;
 unusedpkg)


### PR DESCRIPTION
Implement pagination for retrieving Jamf packages to ensure getting the full list on large instances.