### PR TITLE
Ensure `skip_if` cannot be inherited

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAPIClientUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAPIClientUploaderBase.py
@@ -172,7 +172,7 @@ class JamfAPIClientUploaderBase(JamfUploaderBase):
         replace_object = self.to_bool(self.env.get("replace_api_client"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAPIRoleUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAPIRoleUploaderBase.py
@@ -105,7 +105,7 @@ class JamfAPIRoleUploaderBase(JamfUploaderBase):
         replace_object = self.to_bool(self.env.get("replace_api_role"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
         object_type = "api_role"
 
         # verify that max_tries is an integer greater than zero and less than 10

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
@@ -170,7 +170,7 @@ class JamfAccountUploaderBase(JamfUploaderBase):
         replace_account = self.to_bool(self.env.get("replace_account"))
         max_tries = self.env.get("max_tries")
         sleep_time = self.env.get("sleep")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfCategoryUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfCategoryUploaderBase.py
@@ -120,7 +120,7 @@ class JamfCategoryUploaderBase(JamfUploaderBase):
         replace_category = self.to_bool(self.env.get("replace_category"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupDeleterBase.py
@@ -84,7 +84,7 @@ class JamfComputerGroupDeleterBase(JamfUploaderBase):
         jamf_cli_profile = self.env.get("JAMF_CLI_PROFILE")
         computergroup_name = self.env.get("computergroup_name")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupUploaderBase.py
@@ -138,7 +138,7 @@ class JamfComputerGroupUploaderBase(JamfUploaderBase):
         replace_group = self.to_bool(self.env.get("replace_group"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerPreStageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerPreStageUploaderBase.py
@@ -113,7 +113,7 @@ class JamfComputerPreStageUploaderBase(JamfUploaderBase):
         replace_prestage = self.to_bool(self.env.get("replace_prestage"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
         object_type = "computer_prestage"
 
         # verify that max_tries is an integer greater than zero and less than 10

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
@@ -283,7 +283,7 @@ class JamfComputerProfileUploaderBase(JamfUploaderBase):
         retain_scope = self.to_bool(self.env.get("retain_scope"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerStaticGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerStaticGroupUploaderBase.py
@@ -144,7 +144,7 @@ class JamfComputerStaticGroupUploaderBase(JamfUploaderBase):
         clear_assignments = self.to_bool(self.env.get("clear_assignments"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfDockItemUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfDockItemUploaderBase.py
@@ -119,7 +119,7 @@ class JamfDockItemUploaderBase(JamfUploaderBase):
         replace_dock_item = self.to_bool(self.env.get("replace_dock_item"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributePopupChoiceAdjusterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributePopupChoiceAdjusterBase.py
@@ -272,7 +272,7 @@ class JamfExtensionAttributePopupChoiceAdjusterBase(JamfUploaderBase):
         output_dir = self.env.get("output_dir") or self.env.get("RECIPE_CACHE_DIR")
         choice_value = self.env.get("choice_value")
         strict_mode = self.to_bool(self.env.get("strict_mode"))
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
@@ -175,7 +175,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         replace_ea = self.to_bool(self.env.get("replace_ea"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfIconUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfIconUploaderBase.py
@@ -130,7 +130,7 @@ class JamfIconUploaderBase(JamfUploaderBase):
         icon_uri = self.env.get("icon_uri")
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMSUPlanUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMSUPlanUploaderBase.py
@@ -181,7 +181,7 @@ class JamfMSUPlanUploaderBase(JamfUploaderBase):
         group_name = self.env.get("group_name")
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
@@ -130,7 +130,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         macapp_updated = False
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceAppUploaderBase.py
@@ -156,7 +156,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         mobiledeviceapp_updated = False
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceExtensionAttributeUploaderBase.py
@@ -161,7 +161,7 @@ class JamfMobileDeviceExtensionAttributeUploaderBase(JamfUploaderBase):
         replace_ea = self.to_bool(self.env.get("replace_ea"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceGroupUploaderBase.py
@@ -120,7 +120,7 @@ class JamfMobileDeviceGroupUploaderBase(JamfUploaderBase):
         replace_group = self.to_bool(self.env.get("replace_group"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
         group_uploaded = False
 
         # verify that max_tries is an integer greater than zero and less than 10

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
@@ -225,7 +225,7 @@ class JamfMobileDeviceProfileUploaderBase(JamfUploaderBase):
         replace_profile = self.to_bool(self.env.get("replace_profile"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceStaticGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceStaticGroupUploaderBase.py
@@ -145,7 +145,7 @@ class JamfMobileDeviceStaticGroupUploaderBase(JamfUploaderBase):
         clear_assignments = self.to_bool(self.env.get("clear_assignments"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectDeleterBase.py
@@ -50,7 +50,7 @@ class JamfObjectDeleterBase(JamfUploaderBase):
         jamf_cli_profile = self.env.get("JAMF_CLI_PROFILE")
         object_name = self.env.get("object_name")
         object_type = self.env.get("object_type")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # clear any pre-existing summary result
         if "jamfobjectdeleter_summary_result" in self.env:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectReaderBase.py
@@ -188,7 +188,7 @@ class JamfObjectReaderBase(JamfUploaderBase):
         elements_to_retain = (
             [elements_to_retain] if isinstance(elements_to_retain, str) else []
         )
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # check for required variables
         if not all_objects and not list_only and not "_settings" in object_type:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectStateChangerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectStateChangerBase.py
@@ -198,7 +198,7 @@ class JamfObjectStateChangerBase(JamfUploaderBase):
         retain_data = self.to_bool(self.env.get("retain_data"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
@@ -180,7 +180,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
         replacement_value = self.env.get("replacement_value")
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageCleanerBase.py
@@ -113,7 +113,7 @@ class JamfPackageCleanerBase(JamfUploaderBase):
         )
         dry_run = self.to_bool(self.env.get("dry_run"))
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageRecalculatorBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageRecalculatorBase.py
@@ -81,7 +81,7 @@ class JamfPackageRecalculatorBase(JamfUploaderBase):
         client_secret = self.env.get("CLIENT_SECRET")
         bearer_token = self.env.get("BEARER_TOKEN")
         jamf_cli_profile = self.env.get("JAMF_CLI_PROFILE")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
@@ -541,20 +541,20 @@ class JamfPackageUploaderBase(JamfUploaderBase):
                     size_is_zero = False  # empty string or None — not yet computed, not a failure
                 if size_is_zero:
                     self.output(
-                        f"WARNING: Package '{pkg_name}' — server reported size=0, "
+                        f"WARNING: Package '{pkg_name}' — server reported size=0 after {elapsed}s, "
                         "indicating a failed upload",
                         verbose_level=1,
                     )
                     return False
                 if sha3512 == local_sha3:
                     self.output(
-                        f"Package '{pkg_name}' hash verified (SHA3-512 match)",
+                        f"Package '{pkg_name}' hash verified after {elapsed}s (SHA3-512 match)",
                         verbose_level=1,
                     )
                     return True
                 else:
                     self.output(
-                        f"WARNING: Package '{pkg_name}' hash mismatch — "
+                        f"WARNING: Package '{pkg_name}' hash mismatch after {elapsed}s — "
                         f"server={sha3512}, local={local_sha3}",
                         verbose_level=1,
                     )

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
@@ -617,7 +617,7 @@ class JamfPackageUploaderBase(JamfUploaderBase):
         pkg_uploaded = False
         pkg_metadata_updated = False
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPatchCheckerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPatchCheckerBase.py
@@ -128,7 +128,7 @@ class JamfPatchCheckerBase(JamfUploaderBase):
         pkg_name = self.env.get("pkg_name")
         version = self.env.get("version")
         patch_softwaretitle = self.env.get("patch_softwaretitle")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # Clear any pre-existing summary result
         if "jamfpatchchecker_summary_result" in self.env:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
@@ -275,7 +275,7 @@ class JamfPatchUploaderBase(JamfUploaderBase):
         replace_patchpolicy = self.to_bool(self.env.get("replace_patch"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPkgMetadataUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPkgMetadataUploaderBase.py
@@ -211,7 +211,7 @@ class JamfPkgMetadataUploaderBase(JamfUploaderBase):
         send_notification = self.to_bool(self.env.get("send_notification"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyDeleterBase.py
@@ -80,7 +80,7 @@ class JamfPolicyDeleterBase(JamfUploaderBase):
         jamf_cli_profile = self.env.get("JAMF_CLI_PROFILE")
         policy_name = self.env.get("policy_name")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyLogFlusherBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyLogFlusherBase.py
@@ -94,7 +94,7 @@ class JamfPolicyLogFlusherBase(JamfUploaderBase):
         logflush_interval = self.env.get("logflush_interval")
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
@@ -232,7 +232,7 @@ class JamfPolicyUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         replace_icon = self.to_bool(self.env.get("replace_icon"))
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfScopeAdjusterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfScopeAdjusterBase.py
@@ -291,7 +291,7 @@ class JamfScopeAdjusterBase(JamfUploaderBase):
         scopeable_name = self.env.get("scopeable_name")
         strict_mode = self.to_bool(self.env.get("strict_mode"))
         strip_raw_xml = self.to_bool(self.env.get("strip_raw_xml"))
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         process_skipped = False
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
@@ -183,7 +183,7 @@ class JamfScriptUploaderBase(JamfUploaderBase):
         replace_script = self.to_bool(self.env.get("replace_script"))
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
@@ -153,7 +153,7 @@ class JamfSoftwareRestrictionUploaderBase(JamfUploaderBase):
         kill_process = self.to_bool(self.env.get("kill_process"))
         delete_executable = self.to_bool(self.env.get("delete_executable"))
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUnusedPackageCleanerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUnusedPackageCleanerBase.py
@@ -316,7 +316,7 @@ class JamfUnusedPackageCleanerBase(JamfUploaderBase):
         output_dir = self.env.get("output_dir")
         slack_webhook_url = self.env.get("slack_webhook_url")
         max_tries = self.env.get("max_tries")
-        skip_if = self.env.get("skip_if")
+        skip_if = self.get_and_clear_skip_if()
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -72,6 +72,13 @@ class JamfUploaderBase(Processor):
         self.output(f"({predicate_string}) is {result}", verbose_level=2)
         return result
 
+    def get_and_clear_skip_if(self):
+        """Read skip_if from env and immediately remove it so subsequent processors
+        cannot inherit the value through the shared AutoPkg environment."""
+        skip_if = self.env.get("skip_if")
+        self.env.pop("skip_if", None)
+        return skip_if
+
     def _get_registry(self, jamf_url):
         """Return the shared JamfSchemaRegistry, creating it on first use.
 

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -55,7 +55,7 @@ class JamfUploaderBase(Processor):
     """Common functions used by at least two JamfUploader processors."""
 
     # Global version
-    __version__ = "2026.06.22.0"
+    __version__ = "2026.06.30.0"
 
     # Schema registry instance — lazily initialised per processor run
     _registry = None

--- a/_tests/test_poll_pkg_hash.py
+++ b/_tests/test_poll_pkg_hash.py
@@ -1,0 +1,168 @@
+#!/usr/local/autopkg/python
+"""Unit tests for poll_pkg_hash — exercises hash/size verification logic without a live server.
+
+Run with:
+    /usr/local/autopkg/python _tests/test_poll_pkg_hash.py
+"""
+
+import sys
+from time import sleep as _real_sleep
+
+
+LOCAL_SHA3 = "aabbcc" * 10   # fake but consistent local hash
+OLD_HASH = "112233" * 10     # hash the server held before upload
+MISMATCHED_HASH = "deadbeef" * 6  # a different hash that doesn't match local
+
+
+def _noop_sleep(_):
+    pass
+
+
+def make_obj(responses):
+    """Return a minimal object with poll_pkg_hash wired up, whose
+    get_pkg_server_sha3_and_size cycles through the provided (sha3512, size) tuples."""
+
+    class _Obj:
+        def __init__(self, responses):
+            self._iter = iter(responses)
+            self._messages = []
+
+        def get_pkg_server_sha3_and_size(self, api_url, pkg_id, token, tenant_id=""):
+            return next(self._iter)
+
+        def output(self, msg, verbose_level=1):
+            self._messages.append(msg)
+
+        def poll_pkg_hash(
+            self,
+            api_url,
+            pkg_id,
+            pkg_name,
+            local_sha3,
+            previous_hash,
+            token,
+            poll_interval=15,
+            poll_timeout=300,
+            tenant_id="",
+        ):
+            elapsed = 0
+            while elapsed < poll_timeout:
+                sha3512, size = self.get_pkg_server_sha3_and_size(
+                    api_url, pkg_id, token, tenant_id
+                )
+                if sha3512 and sha3512 != previous_hash:
+                    try:
+                        size_is_zero = int(size) == 0
+                    except (ValueError, TypeError):
+                        size_is_zero = False
+                    if size_is_zero:
+                        self.output(
+                            f"WARNING: Package '{pkg_name}' — server reported size=0, "
+                            "indicating a failed upload",
+                            verbose_level=1,
+                        )
+                        return False
+                    if sha3512 == local_sha3:
+                        self.output(
+                            f"Package '{pkg_name}' hash verified (SHA3-512 match)",
+                            verbose_level=1,
+                        )
+                        return True
+                    else:
+                        self.output(
+                            f"WARNING: Package '{pkg_name}' hash mismatch — "
+                            f"server={sha3512}, local={local_sha3}",
+                            verbose_level=1,
+                        )
+                        return False
+                self.output(
+                    f"Waiting for server to compute hash for '{pkg_name}' "
+                    f"(elapsed {elapsed}s / {poll_timeout}s) …",
+                    verbose_level=2,
+                )
+                elapsed += poll_interval
+
+            self.output(
+                f"WARNING: Timed out waiting for server hash for '{pkg_name}' "
+                f"after {poll_timeout}s",
+                verbose_level=1,
+            )
+            return False
+
+    return _Obj(responses)
+
+
+def run(label, obj, expected):
+    result = obj.poll_pkg_hash(
+        api_url="https://example.jamfcloud.com",
+        pkg_id="1",
+        pkg_name="Test.pkg",
+        local_sha3=LOCAL_SHA3,
+        previous_hash=OLD_HASH,
+        token="fake-token",
+        poll_interval=1,
+        poll_timeout=5,
+    )
+    status = "PASS" if result == expected else "FAIL"
+    print(f"[{status}] {label}")
+    if result != expected:
+        print(f"       expected={expected}, got={result}")
+        for m in obj._messages:
+            print(f"       > {m}")
+    return result == expected
+
+
+passed = 0
+total = 0
+
+# --- Test 1: hash matches local, size is an integer > 0 → success
+total += 1
+passed += run("Hash matches, size=12345 (int) → True", make_obj([(LOCAL_SHA3, 12345)]), True)
+
+# --- Test 2: hash matches local, size is empty string (common in practice) → success
+total += 1
+passed += run("Hash matches, size='' (empty string) → True", make_obj([(LOCAL_SHA3, "")]), True)
+
+# --- Test 3: size == 0 as integer → failure (upload error)
+total += 1
+passed += run("Hash matches, size=0 (int) → False", make_obj([(LOCAL_SHA3, 0)]), False)
+
+# --- Test 4: size == "0" as string → failure (upload error)
+total += 1
+passed += run("Hash matches, size='0' (string) → False", make_obj([(LOCAL_SHA3, "0")]), False)
+
+# --- Test 5: hash mismatch (corruption) → failure
+total += 1
+passed += run("Hash mismatch, size=12345 → False", make_obj([(MISMATCHED_HASH, 12345)]), False)
+
+# --- Test 6: hash mismatch with empty size → failure
+total += 1
+passed += run("Hash mismatch, size='' → False", make_obj([(MISMATCHED_HASH, "")]), False)
+
+# --- Test 7: server returns old hash first, then correct hash → success (two polls)
+total += 1
+passed += run(
+    "Old hash first, then match → True (polls twice)",
+    make_obj([(OLD_HASH, ""), (LOCAL_SHA3, "")]),
+    True,
+)
+
+# --- Test 8: server returns empty hash first, then correct hash → success
+total += 1
+passed += run(
+    "Empty hash first, then match → True (polls twice)",
+    make_obj([("", ""), (LOCAL_SHA3, 9999)]),
+    True,
+)
+
+# --- Test 9: timeout — server never returns a new hash
+# poll_timeout=5, poll_interval=1 → 5 iterations before exit; supply 10 stale responses
+total += 1
+passed += run(
+    "Timeout — hash never computed → False",
+    make_obj([("", "")] * 10),
+    False,
+)
+
+print(f"\n{passed}/{total} tests passed")
+sys.exit(0 if passed == total else 1)


### PR DESCRIPTION
Prevent inheritance of the `skip_if` variable by implementing a method to retrieve and clear its value. Additionally, update the version and include time elapsed in the poll output.