### PR TITLE
Add sleep parameter to JamfPolicyLogFlusher

### DIFF
--- a/JamfUploaderProcessors/JamfPolicyLogFlusher.py
+++ b/JamfUploaderProcessors/JamfPolicyLogFlusher.py
@@ -105,7 +105,7 @@ class JamfPolicyLogFlusher(JamfPolicyLogFlusherBase):
             "description": "Policy whose log is to be flushed",
             "default": "",
         },
-         "sleep": {
+        "sleep": {
             "required": False,
             "description": "Pause after running this processor for specified seconds.",
             "default": "0",

--- a/JamfUploaderProcessors/JamfPolicyLogFlusher.py
+++ b/JamfUploaderProcessors/JamfPolicyLogFlusher.py
@@ -105,6 +105,11 @@ class JamfPolicyLogFlusher(JamfPolicyLogFlusherBase):
             "description": "Policy whose log is to be flushed",
             "default": "",
         },
+         "sleep": {
+            "required": False,
+            "description": "Pause after running this processor for specified seconds.",
+            "default": "0",
+        },
         "logflush_interval": {
             "required": False,
             "description": "Log interval to be flushed",


### PR DESCRIPTION
Fixes issue where JamfPolicyLogFlusherBase expects the sleep parameter but none is passed.