### PR TITLE
Add sleep parameter to JamfPolicyLogFlusher and update READMEs

### DIFF
--- a/JamfUploaderProcessors/JamfPolicyLogFlusher.py
+++ b/JamfUploaderProcessors/JamfPolicyLogFlusher.py
@@ -105,7 +105,7 @@ class JamfPolicyLogFlusher(JamfPolicyLogFlusherBase):
             "description": "Policy whose log is to be flushed",
             "default": "",
         },
-         "sleep": {
+        "sleep": {
             "required": False,
             "description": "Pause after running this processor for specified seconds.",
             "default": "0",

--- a/JamfUploaderProcessors/JamfPolicyLogFlusher.py
+++ b/JamfUploaderProcessors/JamfPolicyLogFlusher.py
@@ -105,6 +105,11 @@ class JamfPolicyLogFlusher(JamfPolicyLogFlusherBase):
             "description": "Policy whose log is to be flushed",
             "default": "",
         },
+         "sleep": {
+            "required": False,
+            "description": "Pause after running this processor for specified seconds.",
+            "default": "0",
+        },
         "logflush_interval": {
             "required": False,
             "description": "Log interval to be flushed",

--- a/JamfUploaderProcessors/READMEs/AppStoreInfoProvider.md
+++ b/JamfUploaderProcessors/READMEs/AppStoreInfoProvider.md
@@ -1,0 +1,37 @@
+# AppStoreInfoProvider
+
+## Description
+
+A processor for AutoPkg that provides metadata from the iTunes/App Store Search API.
+
+## Input variables
+
+- **app_store_url:**
+  - **required:** False
+  - **description:** App Store URL (e.g., https://apps.apple.com/gb/app/name/id284882215)
+- **app_store_id:**
+  - **required:** False
+  - **description:** App Store ID (e.g., 284882215)
+
+## Output variables
+
+- **track_name:**
+  - **description:** Name of the app.
+- **track_view_url:**
+  - **description:** URL to the app in the App Store.
+- **bundle_id:**
+  - **description:** Bundle identifier.
+- **version:**
+  - **description:** Current version.
+- **minimum_os_version:**
+  - **description:** Minimum OS version required.
+- **release_date:**
+  - **description:** Release date.
+- **description:**
+  - **description:** App description.
+- **seller_name:**
+  - **description:** Developer/seller name.
+- **track_id:**
+  - **description:** App Store track ID.
+- **artwork_path:**
+  - **description:** Full path to downloaded artwork file.

--- a/JamfUploaderProcessors/READMEs/ConvertGroupXMLtoJSON.md
+++ b/JamfUploaderProcessors/READMEs/ConvertGroupXMLtoJSON.md
@@ -1,0 +1,23 @@
+# ConvertGroupXMLtoJSON
+
+## Description
+
+A processor for AutoPkg that converts a Classic API group XML definition to JSON format for use with the Jamf Pro API.
+
+## Input variables
+
+- **group_xml_path:**
+  - **required:** True
+  - **description:** Path to the XML file containing the Classic API group definition.
+- **group_json_path:**
+  - **required:** False
+  - **description:** Path where the converted JSON file should be written. If not provided, the JSON will be output to the AutoPkg environment.
+
+## Output variables
+
+- **group_json_data:**
+  - **description:** String containing the converted JSON group data.
+- **is_smart_group:**
+  - **description:** Boolean indicating whether the group is a smart group.
+- **group_name:**
+  - **description:** Name of the group.

--- a/JamfUploaderProcessors/READMEs/JamfAPIClientUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfAPIClientUploader.md
@@ -1,4 +1,4 @@
-# JamfAPIRoleUploader
+# JamfAPIClientUploader
 
 ## Description
 
@@ -21,6 +21,21 @@ A processor for AutoPkg that will create or amend an API Client to a Jamf Pro se
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **api_client_name:**
   - **required:** True
   - **description:** API Client name.
@@ -28,7 +43,7 @@ A processor for AutoPkg that will create or amend an API Client to a Jamf Pro se
   - **required:** False
   - **description:** API Client ID.
 - **api_role_name:**
-  - **required:** True
+  - **required:** False
   - **description:** API Role name that will be assigned to this API Client. Only one API Role can be given to each API Client using this processor.
 - **access_token_lifetime:**
   - **required:** False
@@ -68,5 +83,7 @@ A processor for AutoPkg that will create or amend an API Client to a Jamf Pro se
   - **description:** API Client ID.
 - **api_client_secret:**
   - **description:** API Client Secret.
-- **api_client_updated:**
-  - **description:** Boolean - True if the API Client was changed.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfAPIRoleUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfAPIRoleUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will create or amend an API Role to a Jamf Pro serv
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **api_role_name:**
   - **required:** True
   - **description:** API Role name
@@ -55,3 +70,7 @@ A processor for AutoPkg that will create or amend an API Role to a Jamf Pro serv
   - **description:** API Role name.
 - **api_role_updated:**
   - **description:** Boolean - True if the API Role was changed.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfAccountUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfAccountUploader.md
@@ -21,12 +21,35 @@ A processor for AutoPkg that will upload an account to a Jamf Cloud or on-prem s
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **account_name:**
   - **required:** True
   - **description:** Account name
 - **account_type:**
   - **required:** True
   - **description:** Account type; "user" or "group"
+- **domain:**
+  - **required:** False
+  - **description:** LDAP domain, required if writing an LDAP group.
+  - **default:** ""
+- **group:**
+  - **required:** False
+  - **description:** Local group, required if giving a user group access.
+  - **default:** ""
 - **account_template:**
   - **required:** True
   - **description:** Full path to the XML template
@@ -60,3 +83,7 @@ A processor for AutoPkg that will upload an account to a Jamf Cloud or on-prem s
   - **description:** Boolean - True if the account was changed.
 - **changed_account_id:**
   - **description:** Jamf object ID of the newly created or modified account.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfCategoryUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfCategoryUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will upload a category to a Jamf Cloud or on-prem s
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **category_name**:
   - **required**: False
   - **description**: Category
@@ -54,3 +69,7 @@ A processor for AutoPkg that will upload a category to a Jamf Cloud or on-prem s
   - **description:** The created/updated category.
 - **jamfcategoryuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfComputerGroupDeleter.md
+++ b/JamfUploaderProcessors/READMEs/JamfComputerGroupDeleter.md
@@ -21,8 +21,23 @@ A processor for AutoPkg that will delete a computer group from a Jamf Cloud or o
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
-- **computer_group_name:**
+- **BEARER_TOKEN:**
   - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
+- **computergroup_name:**
+  - **required:** True
   - **description:** Computer Group name
 - **max_tries:**
   - **required:** False
@@ -40,3 +55,7 @@ A processor for AutoPkg that will delete a computer group from a Jamf Cloud or o
 
 - **jamfcomputergroupdeleter_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfComputerGroupUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfComputerGroupUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will upload a computer group (smart or static) to a
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **computergroup_name**:
   - **required**: False
   - **description**: Computer Group name
@@ -51,3 +66,7 @@ A processor for AutoPkg that will upload a computer group (smart or static) to a
 
 - **jamfcomputergroupuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfComputerPreStageUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfComputerPreStageUploader.md
@@ -1,8 +1,8 @@
-# JamfPolicyLogFlusher
+# JamfComputerPreStageUploader
 
 ## Description
 
-A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-prem server.
+A processor for AutoPkg that will create or update a Computer PreStage Enrollment object on a Jamf Pro server.
 
 ## Input variables
 
@@ -36,17 +36,20 @@ A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-
   - **required:** False
   - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
   - **default:** ""
-- **policy_name:**
-  - **required:** True
-  - **description:** Policy whose log is to be flushed
+- **prestage_name:**
+  - **required:** False
+  - **description:** Name of the object. Required except for settings-related objects.
+- **prestage_template:**
+  - **required:** False
+  - **description:** Full path to the XML template.
+- **replace_prestage:**
+  - **required:** False
+  - **description:** Overwrite an existing object if True.
+  - **default:** False
 - **sleep:**
   - **required:** False
   - **description:** Pause after running this processor for specified seconds.
   - **default:** "0"
-- **logflush_interval:**
-  - **required:** False
-  - **description:** Log interval to be flushed
-  - **default:** "Zero Days"
 - **max_tries:**
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
@@ -61,8 +64,12 @@ A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-
 
 ## Output variables
 
-- **jamfpolicylogflusher_summary_result:**
+- **jamfcomputerprestageuploader_summary_result:**
   - **description:** Description of interesting results.
+- **prestage_name:**
+  - **description:** Jamf object name of the newly created or modified object.
+- **prestage_updated:**
+  - **description:** Boolean - True if the object was changed.
 - **process_skipped:**
   - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
 - **dry_run_summary_result:**

--- a/JamfUploaderProcessors/READMEs/JamfComputerProfileUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfComputerProfileUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will upload a computer configuration profile to a J
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **profile_name**:
   - **required**: False
   - **description**: Configuration Profile name
@@ -48,10 +63,6 @@ A processor for AutoPkg that will upload a computer configuration profile to a J
 - **profile_computergroup**:
   - **required**: False
   - **description**: a computer group that will be scoped to the profile
-- **unsign_profile**:
-  - **required**: False
-  - **description**: Unsign a mobileconfig file prior to uploading if it is signed, if true.
-  - **default**: False
 - **replace_profile**:
   - **required**: False
   - **description**: overwrite an existing Configuration Profile if True.
@@ -80,3 +91,7 @@ A processor for AutoPkg that will upload a computer configuration profile to a J
 
 - **jamfcomputerprofileuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfComputerStaticGroupUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfComputerStaticGroupUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will upload a static computer group to a Jamf Cloud
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **computergroup_name**:
   - **required**: False
   - **description**: Computer Group name
@@ -55,3 +70,7 @@ A processor for AutoPkg that will upload a static computer group to a Jamf Cloud
 
 - **jamfcomputerstaticgroupuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfDockItemUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfDockItemUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will upload a Dock item to a Jamf Cloud or on-prem 
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **dock_item_name**:
   - **required**: True
   - **description**: Dock Item name
@@ -52,5 +67,11 @@ A processor for AutoPkg that will upload a Dock item to a Jamf Cloud or on-prem 
 
 ## Output variables
 
+- **dock_item:**
+  - **description:** The created/updated dock item.
 - **jamfdockitemuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfExtensionAttributePopupChoiceAdjuster.md
+++ b/JamfUploaderProcessors/READMEs/JamfExtensionAttributePopupChoiceAdjuster.md
@@ -35,3 +35,5 @@ A processor for AutoPkg that adds or removes pop-up choices from a Jamf Pro Exte
   - **description**: Full path of the modified object file. Intended to pass to `JamfObjectUploader`.
 - **parsed_object**:
   - **description**: Parsed processed object string. For chaining additional `JamfExtensionAttributePopupChoiceAdjuster` processors.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.

--- a/JamfUploaderProcessors/READMEs/JamfExtensionAttributeUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfExtensionAttributeUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will upload an Extension Attribute item to a Jamf C
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **ea_name**:
   - **required**: False
   - **description**: Extension Attribute name
@@ -34,7 +49,7 @@ A processor for AutoPkg that will upload an Extension Attribute item to a Jamf C
 - **ea_inventory_display:**
   - **required:** False
   - **description:** Inventory Display value for the EA.
-  - **default:** "Extension Attributes"
+  - **default:** "EXTENSION_ATTRIBUTES"
 - **ea_data_type:**
   - **required:** False
   - **description:** Data type for the EA. One of String, Integer or Date.
@@ -79,3 +94,7 @@ A processor for AutoPkg that will upload an Extension Attribute item to a Jamf C
 
 - **jamfextensionattributeuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfIconUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfIconUploader.md
@@ -1,8 +1,8 @@
-# JamfPolicyLogFlusher
+# JamfIconUploader
 
 ## Description
 
-A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-prem server.
+A processor for AutoPkg that will upload an icon to a Jamf Cloud or on-prem server. Note that an icon can only be successfully injected into a Mac App Store app item if Cloud Services Connection is enabled.
 
 ## Input variables
 
@@ -36,17 +36,18 @@ A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-
   - **required:** False
   - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
   - **default:** ""
-- **policy_name:**
-  - **required:** True
-  - **description:** Policy whose log is to be flushed
+- **icon_file:**
+  - **required:** False
+  - **description:** An icon to upload.
+  - **default:** ""
+- **icon_uri:**
+  - **required:** False
+  - **description:** An icon to upload directly from a Jamf Cloud URI.
+  - **default:** ""
 - **sleep:**
   - **required:** False
   - **description:** Pause after running this processor for specified seconds.
   - **default:** "0"
-- **logflush_interval:**
-  - **required:** False
-  - **description:** Log interval to be flushed
-  - **default:** "Zero Days"
 - **max_tries:**
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
@@ -61,7 +62,11 @@ A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-
 
 ## Output variables
 
-- **jamfpolicylogflusher_summary_result:**
+- **selfservice_icon_uri:**
+  - **description:** The uploaded icon's URI.
+- **icon_id:**
+  - **description:** The uploaded icon's ID.
+- **jamficonuploader_summary_result:**
   - **description:** Description of interesting results.
 - **process_skipped:**
   - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.

--- a/JamfUploaderProcessors/READMEs/JamfMSUPlanUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMSUPlanUploader.md
@@ -1,4 +1,4 @@
-# JamfObjectUploader
+# JamfMSUPlanUploader
 
 ## Description
 
@@ -21,8 +21,23 @@ A processor for AutoPkg that will create a Managed Software Update Plan. Current
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **device_type**:
-  - **required**: True
+  - **required**: False
   - **description**: Device type, must be one of 'computer', 'mobile-device', 'apple-tv' (case-insensitive).
 - **group_name**:
   - **required**: True
@@ -60,5 +75,9 @@ A processor for AutoPkg that will create a Managed Software Update Plan. Current
   - **description**: Version type, one of 'latest_minor', 'latest_major', 'latest_any', or 'specific_version'.
 - **specific_version**:
   - **description**: Specific version, if 'version_type' is set to 'specific_version'.
-- **object_updated**:
-  - **description**: The date and time of the plan's forced installation deadline.
+- **force_install_local_datetime:**
+  - **description:** The date and time of the plan's forced installation deadline.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfMacAppUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMacAppUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will update or clone a Mac App Store app object on 
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **macapp_name:**
   - **required:** False
   - **description:** Mac App Store app name
@@ -36,6 +51,10 @@ A processor for AutoPkg that will update or clone a Mac App Store app object on 
 - **macapp_template:**
   - **required:** False
   - **description:** Full path to the XML template
+- **preferred_volume_purchase_location:**
+  - **required:** False
+  - **description:** Text to match within the Volume Purchasing Location name when prioritizing app content.
+  - **default:** ""
 - **replace_macapp:**
   - **required:** False
   - **description:** Overwrite an existing Mac App Store app if True.
@@ -66,3 +85,7 @@ A processor for AutoPkg that will update or clone a Mac App Store app object on 
   - **description:** Boolean - True if the macapp was changed.
 - **changed_macapp_id:**
   - **description:** Jamf object ID of the newly created or modified macapp.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfMobileDeviceAppUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMobileDeviceAppUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will update or clone a Mobile Device app object on 
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **mobiledeviceapp_name:**
   - **required:** False
   - **description:** Mobile Device app name
@@ -39,6 +54,10 @@ A processor for AutoPkg that will update or clone a Mobile Device app object on 
 - **appconfig_template:**
   - **required:** False
   - **description:** Full path to the AppConfig XML template
+- **preferred_volume_purchase_location:**
+  - **required:** False
+  - **description:** Text to match within the Volume Purchasing Location name when prioritizing app content.
+  - **default:** ""
 - **replace_mobiledeviceapp:**
   - **required:** False
   - **description:** Overwrite an existing Mobile Device app if True.
@@ -69,3 +88,7 @@ A processor for AutoPkg that will update or clone a Mobile Device app object on 
   - **description:** Boolean - True if the mobiledeviceapp was changed.
 - **changed_mobiledeviceapp_id:**
   - **description:** Jamf object ID of the newly created or modified mobiledeviceapp.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfMobileDeviceExtensionAttributeUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMobileDeviceExtensionAttributeUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will upload a Mobile Device Extension Attribute ite
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **ea_name**:
   - **required**: False
   - **description**: Mobile Device Extension Attribute name
@@ -31,7 +46,7 @@ A processor for AutoPkg that will upload a Mobile Device Extension Attribute ite
 - **ea_inventory_display:**
   - **required:** False
   - **description:** Inventory Display value for the Mobile Device Extension Attribute.
-  - **default:** "Extension Attributes"
+  - **default:** "EXTENSION_ATTRIBUTES"
 - **ea_data_type:**
   - **required:** False
   - **description:** Data type for the Mobile Device Extension Attribute. One of String, Integer or Date.
@@ -69,3 +84,7 @@ A processor for AutoPkg that will upload a Mobile Device Extension Attribute ite
 
 - **jamfmobiledeviceextensionattributeuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfMobileDeviceGroupUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMobileDeviceGroupUploader.md
@@ -1,4 +1,4 @@
-# JamfMobileDeviceUploader
+# JamfMobileDeviceGroupUploader
 
 ## Description
 
@@ -21,10 +21,25 @@ A processor for AutoPkg that will upload a mobile device group (smart or static)
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
-- **mobiledevice_name**:
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
+- **mobiledevicegroup_name**:
   - **required**: False
   - **description**: Mobile Device Group name
-- **mobiledevice_template**:
+- **mobiledevicegroup_template**:
   - **required**: False
   - **description**: Path to Mobile Device Group template file
 - **replace_group**:
@@ -51,3 +66,7 @@ A processor for AutoPkg that will upload a mobile device group (smart or static)
 
 - **jamfmobiledevicegroupuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfMobileDeviceProfileUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMobileDeviceProfileUploader.md
@@ -21,15 +21,27 @@ A processor for AutoPkg that will upload a mobile device configuration profile t
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **profile_name**:
   - **required**: False
   - **description**: Configuration Profile name
 - **mobileconfig**:
   - **required**: False
   - **description**: Path to Configuration Profile mobileconfig file
-- **identifier**:
-  - **required**: False
-  - **description**: Configuration Profile payload identifier
 - **profile_template**:
   - **required**: False
   - **description**: Path to Configuration Profile XML template file
@@ -45,10 +57,6 @@ A processor for AutoPkg that will upload a mobile device configuration profile t
 - **profile_mobiledevicegroup**:
   - **required**: False
   - **description**: a mobile device group that will be scoped to the profile
-- **unsign_profile**:
-  - **required**: False
-  - **description**: Unsign a mobileconfig file prior to uploading if it is signed, if true.
-  - **default**: False
 - **replace_profile**:
   - **required**: False
   - **description**: overwrite an existing Configuration Profile if True.
@@ -73,3 +81,7 @@ A processor for AutoPkg that will upload a mobile device configuration profile t
 
 - **jamfmobiledeviceprofileuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfMobileDeviceStaticGroupUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfMobileDeviceStaticGroupUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will upload a static mobile device group to a Jamf 
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **mobiledevicegroup_name**:
   - **required**: False
   - **description**: Mobile Device Group name
@@ -55,3 +70,7 @@ A processor for AutoPkg that will upload a static mobile device group to a Jamf 
 
 - **jamfmobiledevicestaticgroupuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfObjectDeleter.md
+++ b/JamfUploaderProcessors/READMEs/JamfObjectDeleter.md
@@ -21,12 +21,31 @@ A processor for AutoPkg to delete an API object.
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **object_name**:
-  - **required**: False
+  - **required**: True
   - **description**: The name of the API object
 - **object_type**:
   - **required**: True
   - **description**: The API object type. This is in the singular form - the name of the key in the XML template. See the [Object Reference](./Object%20Reference.md) for valid objects.
+- **max_tries:**
+  - **required:** False
+  - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
+  - **default:** "5"
 - **dry_run:**
   - **required:** False
   - **description:** If True, perform read-only checks and report what would change without making any writes.
@@ -39,5 +58,7 @@ A processor for AutoPkg to delete an API object.
 
 - **jamfobjectdeleter_summary_result:**
   - **description:** Description of interesting results.
-- **object_name**:
-  - **description**: The name of the API object
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfObjectReader.md
+++ b/JamfUploaderProcessors/READMEs/JamfObjectReader.md
@@ -21,12 +21,19 @@ A processor for AutoPkg to read an API object and optionally, output to file (XM
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **object_id**:
+  - **required**: False
+  - **description**: ID of an object. May be used instead of supplying an object name.
 - **object_name**:
   - **required**: False
   - **description**: The name of the API object
-- **object_template**:
-  - **required**: True
-  - **description**: Path to the API object template file
 - **object_type**:
   - **required**: True
   - **description**: The API object type. This is in the singular form - the name of the key in the XML template. See the [Object Reference](./Object%20Reference.md) for valid objects.
@@ -65,6 +72,8 @@ A processor for AutoPkg to read an API object and optionally, output to file (XM
   - **description:** Description of interesting results.
 - **object_name**:
   - **description**: The name of the API object
+- **object_list**:
+  - **description**: A list of all objects.
 - **object_id**:
   - **description**: The ID of the API object
 - **raw_object**:
@@ -73,3 +82,9 @@ A processor for AutoPkg to read an API object and optionally, output to file (XM
   - **description**: String containing parsed XML (removes IDs and computers)
 - **output_dir**:
   - **description**: Directory the xml or json file was saved to.
+- **file_path**:
+  - **description**: Path of outputted results.
+- **payload_file_path**:
+  - **description**: Path of outputted payload.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.

--- a/JamfUploaderProcessors/READMEs/JamfObjectStateChanger.md
+++ b/JamfUploaderProcessors/READMEs/JamfObjectStateChanger.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will change the state of an object on a Jamf Cloud 
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **object_name**:
   - **required**: False
   - **description**: The name of the API object
@@ -32,6 +47,14 @@ A processor for AutoPkg that will change the state of an object on a Jamf Cloud 
   - **required:** True
   - **description:** The desired state of the object, either `enable` or `disable`.
   - **default:** "disable"
+- **retain_data:**
+  - **required:** False
+  - **description:** When disabling a computer extension attribute, set to true to retain existing data. Ignored for other object types.
+  - **default:** True
+- **sleep:**
+  - **required:** False
+  - **description:** Pause after running this processor for specified seconds.
+  - **default:** "0"
 - **max_tries:**
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
@@ -48,3 +71,7 @@ A processor for AutoPkg that will change the state of an object on a Jamf Cloud 
 
 - **jamfobjectstatechanger_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfObjectUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfObjectUploader.md
@@ -21,11 +21,29 @@ A processor for AutoPkg that will upload various Classic API or Jamf Pro API obj
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **object_name**:
   - **required**: False
   - **description**: The name of the API object
+- **object_id**:
+  - **required**: False
+  - **description**: ID of an object. May be used instead of supplying an object name.
 - **object_template**:
-  - **required**: True
+  - **required**: False
   - **description**: Path to the API object template file. For Classic API endpoints this must be XML, for Jamf Pro API endpoints this must be JSON.
 - **object_type**:
   - **required**: True
@@ -33,6 +51,12 @@ A processor for AutoPkg that will upload various Classic API or Jamf Pro API obj
 - **elements_to_remove**:
   - **required**: False
   - **description**: A list of XML or JSON elements that should be removed from the downloaded XML. Note that `id` and `self_service_icon` are removed automatically.
+- **element_to_replace**:
+  - **required**: False
+  - **description**: Full path of an element to replace the value of, such as general/id.
+- **replacement_value**:
+  - **required**: False
+  - **description**: The value of the element provided by the element_to_replace key.
 - **replace_object**:
   - **required**: False
   - **description**: overwrite an existing Computer Group if True.
@@ -59,7 +83,11 @@ A processor for AutoPkg that will upload various Classic API or Jamf Pro API obj
   - **description:** Description of interesting results.
 - **object_name**:
   - **description**: The name of the API object
-- **object_type**:
-  - **description**: This is in the singular form - for Classic API endpoints this is the name of the key in the XML template. For JSON objects it is a construction made interally for this project. See the [Object Reference](./Object%20Reference.md) for valid objects.
 - **object_updated**:
   - **description**: Boolean - True if the object was changed.
+- **failover_url:**
+  - **description:** Failover URL, if uploading failover_generate_command object.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfPackageCleaner.md
+++ b/JamfUploaderProcessors/READMEs/JamfPackageCleaner.md
@@ -21,13 +21,28 @@ A processor for AutoPkg that will remove packages matching a pattern from a Jamf
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **pkg_name_match**:
   - **required**: False
   - **description**: The name at the beginning of the package. This is used as a base for cleaning. If omitted, `%NAME%-`, e.g. `Google Chrome-`, or `%NAME%_`, e.g. =`Google Chrome_`, will be matched.
 - **versions_to_keep**:
   - **required**: False
   - **description**: The number of `pkg_name_match` values to keep in Jamf Pro. This is based on the package ID.
-  - **default**: 3
+  - **default**: "5"
 - **minimum_name_length**:
   - **required**: False
   - **description**: The minimum number of characters required in `pkg_name_match`. This is used as a failsafe.
@@ -52,3 +67,7 @@ A processor for AutoPkg that will remove packages matching a pattern from a Jamf
 
 - **jamfpackagecleaner_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfPackageRecalculator.md
+++ b/JamfUploaderProcessors/READMEs/JamfPackageRecalculator.md
@@ -21,6 +21,25 @@ A processor for AutoPkg that will recalculate the cloud ditribution point invent
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
+- **max_tries:**
+  - **required:** False
+  - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
+  - **default:** "5"
 - **dry_run:**
   - **required:** False
   - **description:** If True, perform read-only checks and report what would change without making any writes.
@@ -33,3 +52,7 @@ A processor for AutoPkg that will recalculate the cloud ditribution point invent
 
 - **jamfpackagerecalculator_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfPackageUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfPackageUploader.md
@@ -15,7 +15,7 @@ Can be run as a post-processor for a pkg recipe or in a child recipe. The parent
   - **required:** False
   - **description:** Package display name, which may be different to the `pkg_name`. If not supplied, reverts to `pkg_name`.
 - **pkg_path:**
-  - **required:** True
+  - **required:** False
   - **description:** Path to a pkg or dmg to import - \*\*provided by previous pkg recipe/processor.
 - **version:**
   - **required:** False
@@ -76,18 +76,36 @@ Can be run as a post-processor for a pkg recipe or in a child recipe. The parent
   - **required:** False
   - **description:** Recalculate the cloud distribution point inventory. Requires Jamf Pro 11.10+ and a configured JCDS endpoint.
   - **default:** False
-- **S3_BUCKET_NAME:**
-  - **required:** False
-  - **description:** The name of an AWS S3 bucket linked to a Jamf Pro server. Required for `aws_cdp_mode`.
 - **JSS_URL:**
   - **required:** True
   - **description:** URL to a Jamf Pro server to which the API user has write access.
 - **API_USERNAME:**
-  - **required:** True
+  - **required:** False
   - **description:** Username of account with appropriate API access to the Jamf Pro Server.
 - **API_PASSWORD:**
-  - **required:** True
-  - **description:** Password of account with appropriate API access to the Jamf Pro Server..
+  - **required:** False
+  - **description:** Password of account with appropriate API access to the Jamf Pro Server.
+- **CLIENT_ID:**
+  - **required:** False
+  - **description:** Client ID with access to access to jss, optionally set as a key in the com.github.autopkg preference file.
+- **CLIENT_SECRET:**
+  - **required:** False
+  - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **CLOUD_DP:**
   - **required:** False
   - **description:** Indicates the presence of a Cloud Distribution Point. The default is deliberately blank. If no SMB DP is configured, the default setting assumes that the Cloud DP has been enabled. If at least one SMB DP is configured, the default setting assumes that no Cloud DP has been set. This can be overridden by setting `CLOUD_DP` to `True`, in which case packages will be uploaded to both a Cloud DP plus the SMB DP(s)."
@@ -103,6 +121,22 @@ Can be run as a post-processor for a pkg recipe or in a child recipe. The parent
 - **SMB_SHARES:**
   - **required:** False
   - **description:** An array of dictionaries containing `SMB_URL`, `SMB_USERNAME` and `SMB_PASSWORD`, as an alternative to individual keys. Any individual keys will override this complete array. The array can only be provided via the AutoPkg preferences file.
+- **show_upload_progress:**
+  - **required:** False
+  - **description:** Show a curl progress bar during package upload.
+  - **default:** False
+- **recalculate_wait_time:**
+  - **required:** False
+  - **description:** Time to wait for recalculation to complete.
+  - **default:** 0
+- **hash_poll_interval:**
+  - **required:** False
+  - **description:** Seconds between polls when waiting for the server to compute the package hash after a JCDS upload.
+  - **default:** 15
+- **hash_poll_timeout:**
+  - **required:** False
+  - **description:** Maximum seconds to wait for the server to compute the package hash after a JCDS upload before treating it as a failure.
+  - **default:** 300
 - **sleep:**
   - **required:** False
   - **description:** Pause after running this processor for specified seconds.
@@ -129,3 +163,7 @@ Can be run as a post-processor for a pkg recipe or in a child recipe. The parent
   - **description:** True/False depending if a package was uploaded or not.
 - **jamfpackageuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfPatchChecker.md
+++ b/JamfUploaderProcessors/READMEs/JamfPatchChecker.md
@@ -21,14 +21,29 @@ A processor for AutoPkg that will check and report whether a Patch Software Titl
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **patch_softwaretitle**:
   - **required**: True
   - **description**: Name of the patch softwaretitle (e.g. 'Mozilla Firefox') used in Jamf. You need to create the patch softwaretitle by hand, since there is currently no way to create these via the API.
 - **pkg_name**:
-  - **required**: True
+  - **required**: False
   - **description**: Name of package which should be used in the patch. Mostly provided by previous AutoPKG recipe/processor.
 - **version**:
-  - **required**: True
+  - **required**: False
   - **description**: Version string - provided by previous pkg recipe/processor.
 - **sleep:**
   - **required:** False
@@ -44,5 +59,9 @@ A processor for AutoPkg that will check and report whether a Patch Software Titl
 
 ## Output variables
 
-- **jamfpatchuploader_summary_result:**
+- **patch_version_found:**
+  - **description:** Returns True if the specified version is found in the patch software title, False otherwise.
+- **jamfpatchchecker_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.

--- a/JamfUploaderProcessors/READMEs/JamfPatchUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfPatchUploader.md
@@ -21,6 +21,29 @@ A processor for AutoPkg that will upload a Patch Policy to a Jamf Cloud or on-pr
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
+- **pkg_name**:
+  - **required**: False
+  - **description**: Name of package which should be used in the patch. Mostly provided by previous AutoPKG recipe/processor.
+  - **default**: ""
+- **version**:
+  - **required**: False
+  - **description**: Version string - provided by previous pkg recipe/processor.
+  - **default**: ""
 - **patch_softwaretitle**:
   - **required**: True
   - **description**: Name of the patch softwaretitle (e.g. 'Mozilla Firefox') used in Jamf. You need to create the patch softwaretitle by hand, since there is currently no way to create these via the API.
@@ -56,5 +79,11 @@ A processor for AutoPkg that will upload a Patch Policy to a Jamf Cloud or on-pr
 
 ## Output variables
 
+- **patch:**
+  - **description:** The patch policy object.
 - **jamfpatchuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfPkgMetadataUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfPkgMetadataUploader.md
@@ -1,14 +1,14 @@
-# JamfPolicyLogFlusher
+# JamfPkgMetadataUploader
 
 ## Description
 
-A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-prem server.
+A processor for AutoPkg that will upload package metadata to Jamf Pro.
 
 ## Input variables
 
 - **JSS_URL:**
   - **required:** True
-  - **description:** URL to a Jamf Pro server that the API user has write access to, optionally set as a key in the com.github.autopkg preference file.
+  - **description:** URL to a Jamf Pro server to which the API user has write access.
 - **API_USERNAME:**
   - **required:** False
   - **description:** Username of account with appropriate access to jss, optionally set as a key in the com.github.autopkg preference file.
@@ -36,20 +36,56 @@ A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-
   - **required:** False
   - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
   - **default:** ""
-- **policy_name:**
-  - **required:** True
-  - **description:** Policy whose log is to be flushed
+- **CLOUD_DP:**
+  - **required:** False
+  - **description:** Indicates the presence of a Cloud Distribution Point. The default is deliberately blank. If no SMB DP is configured, the default setting assumes that the Cloud DP has been enabled. If at least one SMB DP is configured, the default setting assumes that no Cloud DP has been set. This can be overridden by setting `CLOUD_DP` to `True`, in which case packages will be uploaded to both a Cloud DP plus the SMB DP(s).
+- **pkg_name:**
+  - **required:** False
+  - **description:** Package name. If supplied, will rename the package supplied in the pkg_path key when uploading it to the fileshare.
+  - **default:** ""
+- **pkg_display_name:**
+  - **required:** False
+  - **description:** Package display name, which may be different to the `pkg_name`. If not supplied, reverts to `pkg_name`.
+  - **default:** ""
+- **pkg_category:**
+  - **required:** False
+  - **description:** Package category.
+  - **default:** ""
+- **pkg_info:**
+  - **required:** False
+  - **description:** Package info field.
+  - **default:** ""
+- **pkg_notes:**
+  - **required:** False
+  - **description:** Package notes field.
+  - **default:** ""
+- **pkg_priority:**
+  - **required:** False
+  - **description:** Package priority.
+  - **default:** "10"
+- **reboot_required:**
+  - **required:** False
+  - **description:** Whether a package requires a reboot after installation.
+  - **default:** ""
+- **os_requirements:**
+  - **required:** False
+  - **description:** Package OS requirement.
+  - **default:** ""
+- **required_processor:**
+  - **required:** False
+  - **description:** Package required processor. Acceptable values are 'x86' or 'None'.
+  - **default:** "None"
+- **send_notification:**
+  - **required:** False
+  - **description:** Whether to send a notification when a package is installed.
+  - **default:** ""
 - **sleep:**
   - **required:** False
   - **description:** Pause after running this processor for specified seconds.
   - **default:** "0"
-- **logflush_interval:**
-  - **required:** False
-  - **description:** Log interval to be flushed
-  - **default:** "Zero Days"
 - **max_tries:**
   - **required:** False
-  - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
+  - **description:** Maximum number of attempts for uploading package metadata. Must be an integer between 1 and 10.
   - **default:** "5"
 - **dry_run:**
   - **required:** False
@@ -61,7 +97,9 @@ A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-
 
 ## Output variables
 
-- **jamfpolicylogflusher_summary_result:**
+- **pkg_name:**
+  - **description:** The name of the uploaded package.
+- **jamfpkgmetadatauploader_summary_result:**
   - **description:** Description of interesting results.
 - **process_skipped:**
   - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.

--- a/JamfUploaderProcessors/READMEs/JamfPolicyDeleter.md
+++ b/JamfUploaderProcessors/READMEs/JamfPolicyDeleter.md
@@ -21,8 +21,23 @@ A processor for AutoPkg that will delete a policy from a Jamf Cloud or on-prem s
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
-- **policy_name:**
+- **BEARER_TOKEN:**
   - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
+- **policy_name:**
+  - **required:** True
   - **description:** Policy name
 - **max_tries:**
   - **required:** False
@@ -40,3 +55,7 @@ A processor for AutoPkg that will delete a policy from a Jamf Cloud or on-prem s
 
 - **jamfpolicydeleter_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfPolicyUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfPolicyUploader.md
@@ -21,14 +21,29 @@ A processor for AutoPkg that will upload a policy to a Jamf Cloud or on-prem ser
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **policy_name:**
-  - **required:** True
+  - **required:** False
   - **description:** Policy name
 - **icon:**
   - **required:** False
   - **description:** Full path to Self Service icon
 - **policy_template:**
-  - **required:** True
+  - **required:** False
   - **description:** Full path to the XML template
 - **replace_policy:**
   - **required:** False
@@ -68,3 +83,7 @@ A processor for AutoPkg that will upload a policy to a Jamf Cloud or on-prem ser
   - **description:** Boolean - True if the policy was changed.
 - **changed_policy_id:**
   - **description:** Jamf object ID of the newly created or modified policy.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfSchemaLister.md
+++ b/JamfUploaderProcessors/READMEs/JamfSchemaLister.md
@@ -1,0 +1,34 @@
+# JamfSchemaLister
+
+## Description
+
+A processor for AutoPkg that will list all discoverable API endpoints from the Jamf Pro Classic API and JPAPI schemas.
+
+## Input variables
+
+- **JSS_URL:**
+  - **required:** True
+  - **description:** URL to a Jamf Pro server, optionally set as a key in the com.github.autopkg preference file.
+- **api_filter:**
+  - **required:** False
+  - **description:** Filter endpoints by API type. One of 'all', 'classic', or 'jpapi'.
+  - **default:** "all"
+- **show_deprecated:**
+  - **required:** False
+  - **description:** Show deprecated endpoints in the output.
+  - **default:** "False"
+- **output_dir:**
+  - **required:** False
+  - **description:** Optional directory to write the schema listing to a file. Directory must exist.
+- **skip_if:**
+  - **required:** False
+  - **description:** Skip the process if a supplied predicate is met.
+
+## Output variables
+
+- **jamfschemalister_summary_result:**
+  - **description:** Description of interesting results.
+- **schema_lister_output:**
+  - **description:** Text listing of all discovered endpoints.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.

--- a/JamfUploaderProcessors/READMEs/JamfScopeAdjuster.md
+++ b/JamfUploaderProcessors/READMEs/JamfScopeAdjuster.md
@@ -35,6 +35,9 @@ A processor for AutoPkg that adds or removes a scopeable object (target, limitat
 - **output_dir:**  
   - **required:** False  
   - **description:** Directory to save the modified object file. Defaults to `RECIPE_CACHE_DIR`.
+- **skip_if:**
+  - **required:** False
+  - **description:** Skip the process if a supplied predicate is met.
 
 ## Output variables
 
@@ -42,3 +45,5 @@ A processor for AutoPkg that adds or removes a scopeable object (target, limitat
   - **description:** Full path of the modified object file. Intended to be passed to `JamfObjectUploader`.
 - **raw_object:**  
   - **description:** Raw processed XML object string. Can be used for chaining additional `JamfScopeAdjuster` processors.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.

--- a/JamfUploaderProcessors/READMEs/JamfScriptUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfScriptUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will upload a script to a Jamf Cloud or on-prem ser
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **script_path**:
   - **required**: False
   - **description**: Full path to the script to be uploaded
@@ -97,3 +112,7 @@ A processor for AutoPkg that will upload a script to a Jamf Cloud or on-prem ser
   - **description:** Name of the uploaded script
 - **jamfscriptuploader_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfSoftwareRestrictionUploader.md
+++ b/JamfUploaderProcessors/READMEs/JamfSoftwareRestrictionUploader.md
@@ -21,6 +21,21 @@ A processor for AutoPkg that will upload a restricted software record to a Jamf 
 - **CLIENT_SECRET:**
   - **required:** False
   - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+  - **default:** ""
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). Required for Platform API authentication.
+  - **default:** ""
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+  - **default:** ""
 - **restriction_name**:
   - **required**: False
   - **description**: Software Restriction name
@@ -74,5 +89,9 @@ A processor for AutoPkg that will upload a restricted software record to a Jamf 
 
 ## Output variables
 
-- **jamfsoftwarerestrictionuploader_summary_result:**
+- **jamfsoftwarerestrictiontest_summary_result:**
   - **description:** Description of interesting results.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.
+- **dry_run_summary_result:**
+  - **description:** Summary of what would have been changed (only set when dry_run is True).

--- a/JamfUploaderProcessors/READMEs/JamfUnusedPackageCleaner.md
+++ b/JamfUploaderProcessors/READMEs/JamfUnusedPackageCleaner.md
@@ -1,8 +1,8 @@
-# JamfPolicyLogFlusher
+# JamfUnusedPackageCleaner
 
 ## Description
 
-A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-prem server.
+A processor for AutoPkg that will remove unused packages from Jamf Pro.
 
 ## Input variables
 
@@ -36,32 +36,28 @@ A processor for AutoPkg that will flush logs for a policy on a Jamf Cloud or on-
   - **required:** False
   - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
   - **default:** ""
-- **policy_name:**
-  - **required:** True
-  - **description:** Policy whose log is to be flushed
-- **sleep:**
+- **dry_run:**
   - **required:** False
-  - **description:** Pause after running this processor for specified seconds.
-  - **default:** "0"
-- **logflush_interval:**
+  - **description:** If set to True, nothing is deleted from Jamf Pro. Use together with `-vv` for detailed information. This is used for testing.
+  - **default:** False
+- **output_dir:**
   - **required:** False
-  - **description:** Log interval to be flushed
-  - **default:** "Zero Days"
+  - **description:** Output directory to dump the csv file.
+  - **default:** ""
+- **slack_webhook_url:**
+  - **required:** False
+  - **description:** Slack webhook.
 - **max_tries:**
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
-- **dry_run:**
-  - **required:** False
-  - **description:** If True, perform read-only checks and report what would change without making any writes.
-  - **default:** False
 - **skip_if:**
   - **required:** False
   - **description:** Skip the process if a supplied predicate is met.
 
 ## Output variables
 
-- **jamfpolicylogflusher_summary_result:**
+- **jamfunusedpackagecleaner_summary_result:**
   - **description:** Description of interesting results.
 - **process_skipped:**
   - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.

--- a/JamfUploaderProcessors/READMEs/JamfUploaderJiraIssueCreator.md
+++ b/JamfUploaderProcessors/READMEs/JamfUploaderJiraIssueCreator.md
@@ -16,8 +16,11 @@ A postprocessor for AutoPkg that will create a Jira issue based on the output of
   - **required:** False
   - **description:** Category for the created/updated pkg.
 - **NAME:**
-  - **required:** True
+  - **required:** False
   - **description:** Name of the application being created/updated.
+- **CATEGORY:**
+  - **required:** False
+  - **description:** Category.
 - **patch_name:**
   - **required:** False
   - **description:** Name of the Patch Policy being updated.
@@ -39,7 +42,7 @@ A postprocessor for AutoPkg that will create a Jira issue based on the output of
 - **jira_url:**
   - **required:** True
   - **description:** Jira base URL to send the message to (e.g. <https://yourcompany.atlassian.net> - API endpoint not required).
-- **jira_product_id:**
+- **jira_project_id:**
   - **required:** True
   - **description:** Jira Product ID
 - **jira_username:**
@@ -60,3 +63,7 @@ A postprocessor for AutoPkg that will create a Jira issue based on the output of
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+
+## Output variables
+
+This processor has no output variables.

--- a/JamfUploaderProcessors/READMEs/JamfUploaderSlacker.md
+++ b/JamfUploaderProcessors/READMEs/JamfUploaderSlacker.md
@@ -18,8 +18,14 @@ Takes elements from [this gist](https://gist.github.com/devStepsize/b1b795309a21
   - **required:** False
   - **description:** Category for the created/updated pkg.
 - **NAME:**
-  - **required:** True
+  - **required:** False
   - **description:** Name of the application being created/updated.
+- **PROFILE_NAME:**
+  - **required:** False
+  - **description:** Profile name.
+- **PROFILE_CATEGORY:**
+  - **required:** False
+  - **description:** Profile category.
 - **pkg_name:**
   - **required:** False
   - **description:** File name of the pkg being uploaded.
@@ -32,9 +38,30 @@ Takes elements from [this gist](https://gist.github.com/devStepsize/b1b795309a21
 - **jamfpackageuploader_summary_result:**
   - **required:** False
   - **description:** Result of JamfPackageUploader.
+- **jamfpkgmetadatauploader_summary_result:**
+  - **required:** False
+  - **description:** Summary results of package metadata processors.
 - **jamfpolicyuploader_summary_result:**
   - **required:** False
   - **description:** Result of JamfPolicyUploader.
+- **jamfcomputerprofileuploader_summary_result:**
+  - **required:** False
+  - **description:** Summary results of computer profile processors.
+- **jamfmobiledeviceprofilepploader_summary_result:**
+  - **required:** False
+  - **description:** Summary results of mobile device profile processors.
+- **jamfmacappuploader_summary_result:**
+  - **required:** False
+  - **description:** Summary results of Mac App Store App processors.
+- **jamfmobiledeviceappuploader_summary_result:**
+  - **required:** False
+  - **description:** Summary results of Mobile Device App Store App processors.
+- **jamfmsuplanuploader_summary_result:**
+  - **required:** False
+  - **description:** Summary results of MSU Plan processors.
+- **jamfobjectuploader_summary_result:**
+  - **required:** False
+  - **description:** Summary results of generic object uploader processors.
 - **slack_webhook_url:**
   - **required:** True
   - **description:** Slack webhook URL to send the message to.
@@ -54,3 +81,7 @@ Takes elements from [this gist](https://gist.github.com/devStepsize/b1b795309a21
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+
+## Output variables
+
+This processor has no output variables.

--- a/JamfUploaderProcessors/READMEs/JamfUploaderTeamsNotifier.md
+++ b/JamfUploaderProcessors/READMEs/JamfUploaderTeamsNotifier.md
@@ -16,8 +16,11 @@ A postprocessor for AutoPkg that will send details about a recipe run to a Micro
   - **required:** False
   - **description:** Category for the created/updated pkg.
 - **NAME:**
-  - **required:** True
+  - **required:** False
   - **description:** Name of the application being created/updated.
+- **version:**
+  - **required:** False
+  - **description:** Version string - provided by previous pkg recipe/processor.
 - **patch_name:**
   - **required:** False
   - **description:** Name of the Patch Policy being updated.
@@ -49,3 +52,7 @@ A postprocessor for AutoPkg that will send details about a recipe run to a Micro
   - **required:** False
   - **description:** Maximum number of attempts to upload the account. Must be an integer between 1 and 10.
   - **default:** "5"
+
+## Output variables
+
+This processor has no output variables.


### PR DESCRIPTION
Introduce a sleep parameter to the JamfPolicyLogFlusher to allow for a pause after execution. Update various READMEs to reflect changes and improvements in documentation.