### PR TITLE
Move dry_run variable to the top of execute function

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAPIClientUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAPIClientUploaderBase.py
@@ -173,6 +173,7 @@ class JamfAPIClientUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -293,7 +294,7 @@ class JamfAPIClientUploaderBase(JamfUploaderBase):
             verbose_level=2,
         )
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} api_client '{object_name}'")
             self.env["api_client_updated"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAPIRoleUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAPIRoleUploaderBase.py
@@ -106,6 +106,7 @@ class JamfAPIRoleUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
         object_type = "api_role"
 
         # verify that max_tries is an integer greater than zero and less than 10
@@ -197,7 +198,7 @@ class JamfAPIRoleUploaderBase(JamfUploaderBase):
                 )
                 return
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} api_role '{object_name}'")
             self.env["api_role_updated"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfAccountUploaderBase.py
@@ -171,6 +171,7 @@ class JamfAccountUploaderBase(JamfUploaderBase):
         max_tries = self.env.get("max_tries")
         sleep_time = self.env.get("sleep")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -289,7 +290,7 @@ class JamfAccountUploaderBase(JamfUploaderBase):
                 )
                 return
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} account '{account_name}'")
             self.env["account_updated"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfCategoryUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfCategoryUploaderBase.py
@@ -121,6 +121,7 @@ class JamfCategoryUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -201,7 +202,7 @@ class JamfCategoryUploaderBase(JamfUploaderBase):
         else:
             self.output(f"Category '{category_name}' not found: ID {object_id}")
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} category '{category_name}'")
             self.env["category"] = category_name

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupDeleterBase.py
@@ -85,6 +85,7 @@ class JamfComputerGroupDeleterBase(JamfUploaderBase):
         computergroup_name = self.env.get("computergroup_name")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -146,7 +147,7 @@ class JamfComputerGroupDeleterBase(JamfUploaderBase):
 
         if object_id:
             self.output(f"Computer Group '{computergroup_name}' exists: ID {object_id}")
-            if self.env.get("dry_run"):
+            if dry_run:
                 self.output(f"DRY RUN: Would DELETE computer group '{computergroup_name}' (ID {object_id})")
                 self.env["dry_run_summary_result"] = {
                     "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerGroupUploaderBase.py
@@ -139,6 +139,7 @@ class JamfComputerGroupUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -231,7 +232,7 @@ class JamfComputerGroupUploaderBase(JamfUploaderBase):
                 )
                 return
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} computer group '{computergroup_name}'")
             self.env["group_uploaded"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerPreStageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerPreStageUploaderBase.py
@@ -114,6 +114,7 @@ class JamfComputerPreStageUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
         object_type = "computer_prestage"
 
         # verify that max_tries is an integer greater than zero and less than 10
@@ -260,7 +261,7 @@ class JamfComputerPreStageUploaderBase(JamfUploaderBase):
             with open(template_file, "w", encoding="utf-8") as file:
                 file.write(template_contents)
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} computer_prestage '{prestage_name}'")
             self.env["prestage_name"] = prestage_name

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerProfileUploaderBase.py
@@ -284,6 +284,7 @@ class JamfComputerProfileUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -451,7 +452,7 @@ class JamfComputerProfileUploaderBase(JamfUploaderBase):
             tenant_id=jamf_platform_gw_tenant_id,
         )
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} configuration profile '{mobileconfig_name}'")
             self.env["profile_updated"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfComputerStaticGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfComputerStaticGroupUploaderBase.py
@@ -145,6 +145,7 @@ class JamfComputerStaticGroupUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -233,7 +234,7 @@ class JamfComputerStaticGroupUploaderBase(JamfUploaderBase):
                     api_url, object_id, token, tenant_id=jamf_platform_gw_tenant_id
                 )
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} computer_static_group '{computergroup_name}'")
             self.env["group_uploaded"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfDockItemUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfDockItemUploaderBase.py
@@ -120,6 +120,7 @@ class JamfDockItemUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -193,7 +194,7 @@ class JamfDockItemUploaderBase(JamfUploaderBase):
                 )
                 return
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} dock_item '{dock_item_name}'")
             self.env["dock_item_uploaded"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfExtensionAttributeUploaderBase.py
@@ -176,6 +176,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -272,7 +273,7 @@ class JamfExtensionAttributeUploaderBase(JamfUploaderBase):
                 )
                 return
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} extension attribute '{ea_name}'")
             self.env["extension_attribute"] = ea_name

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfIconUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfIconUploaderBase.py
@@ -131,6 +131,7 @@ class JamfIconUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -186,7 +187,7 @@ class JamfIconUploaderBase(JamfUploaderBase):
         if not icon_file:
             raise ProcessorError("ERROR: Icon not found")
 
-        if self.env.get("dry_run"):
+        if dry_run:
             self.output(f"DRY RUN: Would UPLOAD icon '{icon_file}'")
             self.env["dry_run_summary_result"] = {
                 "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMSUPlanUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMSUPlanUploaderBase.py
@@ -182,6 +182,7 @@ class JamfMSUPlanUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -306,7 +307,7 @@ class JamfMSUPlanUploaderBase(JamfUploaderBase):
         # check for an existing object except for settings-related endpoints
         object_type = "managed_software_updates_plans_group_settings"
 
-        if self.env.get("dry_run"):
+        if dry_run:
             self.output(f"DRY RUN: Would CREATE msu_plan for group '{group_name}'")
             self.env["dry_run_summary_result"] = {
                 "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMacAppUploaderBase.py
@@ -131,6 +131,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
         macapp_updated = False
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -200,7 +201,7 @@ class JamfMacAppUploaderBase(JamfUploaderBase):
             tenant_id=jamf_platform_gw_tenant_id,
         )
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} mac_application '{macapp_name}'")
             self.env["macapp_updated"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceAppUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceAppUploaderBase.py
@@ -157,6 +157,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
         mobiledeviceapp_updated = False
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -227,7 +228,7 @@ class JamfMobileDeviceAppUploaderBase(JamfUploaderBase):
             tenant_id=jamf_platform_gw_tenant_id,
         )
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} mobile_device_application '{mobiledeviceapp_name}'")
             self.env["mobiledeviceapp_updated"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceExtensionAttributeUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceExtensionAttributeUploaderBase.py
@@ -162,6 +162,7 @@ class JamfMobileDeviceExtensionAttributeUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -249,7 +250,7 @@ class JamfMobileDeviceExtensionAttributeUploaderBase(JamfUploaderBase):
                 )
                 return
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} mobile_device_extension_attribute '{ea_name}'")
             self.env["ea_uploaded"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceGroupUploaderBase.py
@@ -121,6 +121,7 @@ class JamfMobileDeviceGroupUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
         group_uploaded = False
 
         # verify that max_tries is an integer greater than zero and less than 10
@@ -213,7 +214,7 @@ class JamfMobileDeviceGroupUploaderBase(JamfUploaderBase):
                 )
                 return
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} mobile_device_group '{mobiledevicegroup_name}'")
             self.env["group_uploaded"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceProfileUploaderBase.py
@@ -226,6 +226,7 @@ class JamfMobileDeviceProfileUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -358,7 +359,7 @@ class JamfMobileDeviceProfileUploaderBase(JamfUploaderBase):
             tenant_id=jamf_platform_gw_tenant_id,
         )
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} configuration profile '{mobileconfig_name}'")
             self.env["profile_updated"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceStaticGroupUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfMobileDeviceStaticGroupUploaderBase.py
@@ -146,6 +146,7 @@ class JamfMobileDeviceStaticGroupUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -234,7 +235,7 @@ class JamfMobileDeviceStaticGroupUploaderBase(JamfUploaderBase):
                     api_url, object_id, token, tenant_id=jamf_platform_gw_tenant_id
                 )
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} mobile_device_static_group '{mobiledevicegroup_name}'")
             self.env["group_uploaded"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectDeleterBase.py
@@ -51,6 +51,7 @@ class JamfObjectDeleterBase(JamfUploaderBase):
         object_name = self.env.get("object_name")
         object_type = self.env.get("object_type")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # clear any pre-existing summary result
         if "jamfobjectdeleter_summary_result" in self.env:
@@ -96,7 +97,7 @@ class JamfObjectDeleterBase(JamfUploaderBase):
 
         # cloud_distribution_point endpoint doesn't use IDs or names
         if object_type == "cloud_distribution_point":
-            if self.env.get("dry_run"):
+            if dry_run:
                 self.output(f"DRY RUN: Would DELETE singleton {object_type}")
                 self.env["dry_run_summary_result"] = {
                     "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",
@@ -137,7 +138,7 @@ class JamfObjectDeleterBase(JamfUploaderBase):
 
             if object_id:
                 self.output(f"{object_type} '{object_name}' exists: ID {object_id}")
-                if self.env.get("dry_run"):
+                if dry_run:
                     self.output(f"DRY RUN: Would DELETE {object_type} '{object_name}' (ID {object_id})")
                     self.env["dry_run_summary_result"] = {
                         "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectStateChangerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectStateChangerBase.py
@@ -199,6 +199,7 @@ class JamfObjectStateChangerBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -288,7 +289,7 @@ class JamfObjectStateChangerBase(JamfUploaderBase):
 
         if object_id:
             self.output(f"{object_type} '{object_name}' exists: ID {object_id}")
-            if self.env.get("dry_run"):
+            if dry_run:
                 self.output(f"DRY RUN: Would STATE_CHANGE {object_type} '{object_name}' to {object_state}")
                 self.env["dry_run_summary_result"] = {
                     "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfObjectUploaderBase.py
@@ -181,6 +181,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -372,7 +373,7 @@ class JamfObjectUploaderBase(JamfUploaderBase):
                 namekey_path=namekey_path,
             )
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} {object_type} '{object_name}'")
             self.env["object_name"] = str(object_name)

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageRecalculatorBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageRecalculatorBase.py
@@ -82,6 +82,7 @@ class JamfPackageRecalculatorBase(JamfUploaderBase):
         bearer_token = self.env.get("BEARER_TOKEN")
         jamf_cli_profile = self.env.get("JAMF_CLI_PROFILE")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         process_skipped = False
 
@@ -151,7 +152,7 @@ class JamfPackageRecalculatorBase(JamfUploaderBase):
                 )
             )
 
-            if self.env.get("dry_run"):
+            if dry_run:
                 self.output("DRY RUN: Would recalculate package inventory on Cloud Distribution Point")
                 self.env["dry_run_summary_result"] = {
                     "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPackageUploaderBase.py
@@ -618,6 +618,7 @@ class JamfPackageUploaderBase(JamfUploaderBase):
         pkg_metadata_updated = False
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -823,7 +824,7 @@ class JamfPackageUploaderBase(JamfUploaderBase):
             pkg_id = 0
         self.output(f"Package ID: {object_id}", verbose_level=3)  # TEMP
 
-        if self.env.get("dry_run"):
+        if dry_run:
             if object_id:
                 action = "UPDATE metadata for"
             else:

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPatchUploaderBase.py
@@ -276,6 +276,7 @@ class JamfPatchUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -467,7 +468,7 @@ class JamfPatchUploaderBase(JamfUploaderBase):
                     )
                     return
 
-            if self.env.get("dry_run"):
+            if dry_run:
                 action = "CREATE" if not patch_id else "UPDATE"
                 self.output(f"DRY RUN: Would {action} patch_policy '{patch_name}'")
                 self.env["patch_updated"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPkgMetadataUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPkgMetadataUploaderBase.py
@@ -212,6 +212,7 @@ class JamfPkgMetadataUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -305,7 +306,7 @@ class JamfPkgMetadataUploaderBase(JamfUploaderBase):
             self.output(f"Package '{pkg_name}' not found on server")
             pkg_id = 0
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "UPDATE metadata for" if int(pkg_id) > 0 else "CREATE"
             self.output(f"DRY RUN: Would {action} package '{pkg_name}'")
             self.env["pkg_name"] = pkg_name

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyDeleterBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyDeleterBase.py
@@ -81,6 +81,7 @@ class JamfPolicyDeleterBase(JamfUploaderBase):
         policy_name = self.env.get("policy_name")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -142,7 +143,7 @@ class JamfPolicyDeleterBase(JamfUploaderBase):
 
         if object_id:
             self.output(f"Policy '{policy_name}' exists: ID {object_id}")
-            if self.env.get("dry_run"):
+            if dry_run:
                 self.output(f"DRY RUN: Would DELETE policy '{policy_name}' (ID {object_id})")
                 self.env["dry_run_summary_result"] = {
                     "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyLogFlusherBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyLogFlusherBase.py
@@ -95,6 +95,7 @@ class JamfPolicyLogFlusherBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -156,7 +157,7 @@ class JamfPolicyLogFlusherBase(JamfUploaderBase):
 
         if object_id:
             self.output(f"Policy '{policy_name}' exists: ID {object_id}")
-            if self.env.get("dry_run"):
+            if dry_run:
                 self.output(f"DRY RUN: Would flush policy log for '{policy_name}'")
                 self.env["dry_run_summary_result"] = {
                     "summary_text": "DRY RUN: The following changes would be made in Jamf Pro:",

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfPolicyUploaderBase.py
@@ -233,6 +233,7 @@ class JamfPolicyUploaderBase(JamfUploaderBase):
         replace_icon = self.to_bool(self.env.get("replace_icon"))
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -332,7 +333,7 @@ class JamfPolicyUploaderBase(JamfUploaderBase):
                 )
                 return
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} policy '{policy_name}'")
             self.env["policy_name"] = policy_name

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfScriptUploaderBase.py
@@ -184,6 +184,7 @@ class JamfScriptUploaderBase(JamfUploaderBase):
         sleep_time = self.env.get("sleep")
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -304,7 +305,7 @@ class JamfScriptUploaderBase(JamfUploaderBase):
                 )
                 return
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} script '{script_name}'")
             self.env["script_name"] = script_name

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfSoftwareRestrictionUploaderBase.py
@@ -154,6 +154,7 @@ class JamfSoftwareRestrictionUploaderBase(JamfUploaderBase):
         delete_executable = self.to_bool(self.env.get("delete_executable"))
         max_tries = self.env.get("max_tries")
         skip_if = self.get_and_clear_skip_if()
+        dry_run = self.to_bool(self.env.get("dry_run"))
 
         # verify that max_tries is an integer greater than zero and less than 10
         try:
@@ -252,7 +253,7 @@ class JamfSoftwareRestrictionUploaderBase(JamfUploaderBase):
                 f"Software Restriction '{restriction_name}' not found - will create"
             )
 
-        if self.env.get("dry_run"):
+        if dry_run:
             action = "CREATE" if not object_id else "UPDATE"
             self.output(f"DRY RUN: Would {action} restricted_software '{restriction_name}'")
             self.env["restriction_uploaded"] = False

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -504,7 +504,7 @@ class JamfUploaderBase(Processor):
                             "URL and user for token matches current request",
                             verbose_level=2,
                         )
-                        if data["token"]:
+                        if data.get("token"):
                             try:
                                 # check if it's expired or not
                                 # this may not always work due to inconsistent

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py
@@ -29,13 +29,13 @@ import xml.etree.ElementTree as ET
 from base64 import b64encode
 from collections import abc, namedtuple
 from datetime import datetime, timedelta, timezone
-from Foundation import NSPredicate
 from pathlib import Path
 from shutil import rmtree
 from time import sleep
 from urllib.parse import quote, urlparse
 from uuid import UUID
 from xml.sax.saxutils import escape
+from Foundation import NSPredicate  # pylint: disable=import-error
 
 from autopkglib import (  # pylint: disable=import-error
     Processor,
@@ -1342,7 +1342,12 @@ class JamfUploaderBase(Processor):
         tmp_dir = self.make_tmp_dir(jamf_url=url)
 
         # dry-run: skip write operations but allow auth/token requests
-        if self.env.get("dry_run") and request in ("POST", "PUT", "PATCH", "DELETE"):
+        if self.to_bool(self.env.get("dry_run")) and request in (
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE",
+        ):
             if endpoint_type not in ("oauth", "token", "auth", "platform_api_token"):
                 self.output(f"DRY RUN: Would {request} to {url}")
                 r = namedtuple(
@@ -1425,7 +1430,9 @@ class JamfUploaderBase(Processor):
             curl_cmd.extend(["--show-error"])
 
             # we want to be silent except for package uploads with progress enabled
-            if endpoint_type != "package_v1" or not self.env.get("show_upload_progress"):
+            if endpoint_type != "package_v1" or not self.env.get(
+                "show_upload_progress"
+            ):
                 curl_cmd.extend(["--silent"])
 
             # icon download


### PR DESCRIPTION
This change improves code clarity by defining the `dry_run` variable at the beginning of the `execute` function, ensuring consistent usage throughout the function.