### PR TITLE
Handle ProcessorError when retrieving patch software titles

### DIFF
--- a/JamfUploaderProcessors/JamfUploaderLib/JamfUnusedPackageCleanerBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfUnusedPackageCleanerBase.py
@@ -93,9 +93,16 @@ class JamfUnusedPackageCleanerBase(JamfUploaderBase):
         """get a list of all packages in all patch software titles"""
 
         # get all patch software titles
-        titles = self.get_all_api_objects(
-            api_url, "patch_software_title", token=token, tenant_id=tenant_id
-        )
+        try:
+            titles = self.get_all_api_objects(
+                api_url, "patch_software_title", token=token, tenant_id=tenant_id
+            )
+        except ProcessorError:
+            self.output(
+                "Unable to get patch software titles - assuming none exist",
+                verbose_level=1,
+            )
+            return None
 
         # get all package objects from patch titles and add to a list
         if titles:


### PR DESCRIPTION
Handle the ProcessorError exception to provide a more graceful response when patch software titles cannot be retrieved. This change improves error handling and user feedback in the process.