### PR TITLE
feat: add JamfDirectoryServiceGroupEncoder

### DIFF
--- a/JamfUploaderProcessors/CHANGELOG.md
+++ b/JamfUploaderProcessors/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The dates here represent when the features were added to the processors in the `jamf-upload` repo.
 
+## 2026-08-19
+
+* Added `JamfDirectoryServiceGroupEncoder`, which resolves a Directory Service (LDAP/IdP) group name to the base64-encoded `{uuid,serverId}` value required by *directory service group* criteria in smart groups and advanced searches (Jamf Pro 11.29 and later). The encoded value is returned as an output variable for substitution into a template uploaded by `JamfComputerGroupUploader`, `JamfMobileDeviceGroupUploader` or `JamfObjectUploader`.
+
 ## 2026-05-29
 
 * Added `dry_run` option to all processors. When set to `True`, processors perform read-only checks and report what would change without making any writes to the Jamf Pro server.

--- a/JamfUploaderProcessors/JamfDirectoryServiceGroupEncoder.py
+++ b/JamfUploaderProcessors/JamfDirectoryServiceGroupEncoder.py
@@ -1,0 +1,161 @@
+#!/usr/local/autopkg/python
+
+"""
+2026 Neil Martin
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+NOTES:
+All functions are in JamfUploaderLib/JamfDirectoryServiceGroupEncoderBase.py
+"""
+
+import os.path
+import sys
+
+# to use a base module in AutoPkg we need to add this path to the sys.path.
+# this violates flake8 E402 (PEP8 imports) but is unavoidable, so the following
+# imports require noqa comments for E402
+sys.path.insert(0, os.path.dirname(__file__))
+
+from JamfUploaderLib.JamfDirectoryServiceGroupEncoderBase import (  # noqa: E402
+    JamfDirectoryServiceGroupEncoderBase,
+)
+
+__all__ = ["JamfDirectoryServiceGroupEncoder"]
+
+
+class JamfDirectoryServiceGroupEncoder(JamfDirectoryServiceGroupEncoderBase):
+    description = (
+        "A processor for AutoPkg that resolves a directory service group "
+        "name to the base64-encoded {uuid,serverId} value required by directory "
+        "service group smart group and advanced search criteria (Jamf Pro 11.29+). "
+        "Outputs directory_service_group_value for substitution into a template."
+    )
+
+    input_variables = {
+        "JSS_URL": {
+            "required": True,
+            "description": "URL to a Jamf Pro server that the API user has write access "
+            "to, optionally set as a key in the com.github.autopkg "
+            "preference file.",
+        },
+        "API_USERNAME": {
+            "required": False,
+            "description": "Username of account with appropriate access to "
+            "jss, optionally set as a key in the com.github.autopkg "
+            "preference file.",
+        },
+        "API_PASSWORD": {
+            "required": False,
+            "description": "Password of api user, optionally set as a key in "
+            "the com.github.autopkg preference file.",
+        },
+        "CLIENT_ID": {
+            "required": False,
+            "description": "Client ID with access to "
+            "jss, optionally set as a key in the com.github.autopkg "
+            "preference file.",
+        },
+        "CLIENT_SECRET": {
+            "required": False,
+            "description": "Secret associated with the Client ID, optionally set as a key in "
+            "the com.github.autopkg preference file.",
+        },
+        "BEARER_TOKEN": {
+            "required": False,
+            "description": "A pre-existing bearer token for the Jamf Pro API. "
+            "If provided, the token will be validated and used directly, "
+            "bypassing credential-based authentication.",
+        },
+        "JAMF_CLI_PROFILE": {
+            "required": False,
+            "description": "A jamf-cli profile to use to obtain a bearer token. "
+            "Requires jamf-cli to be installed and in the PATH. "
+            "Set to a profile name to enable.",
+            "default": "",
+        },
+        "PLATFORM_API_REGION": {
+            "required": False,
+            "description": "Region for Jamf Platform API Gateway (e.g., 'us1', 'eu1', 'au1'). "
+            "Required for Platform API authentication.",
+            "default": "",
+        },
+        "PLATFORM_API_TENANT_ID": {
+            "required": False,
+            "description": "Tenant ID for Jamf Platform API Gateway. "
+            "Required for Platform API authentication.",
+            "default": "",
+        },
+        "directory_service_group_name": {
+            "required": False,
+            "description": "Name of the directory service group to resolve. Must match the "
+            "group name in the directory exactly (case-sensitive). An already-encoded "
+            "base64 value may also be supplied, in which case it is validated and passed "
+            "through unchanged. Not required if directory_service_group_uuid and "
+            "directory_service_group_server_id are both supplied.",
+            "default": "",
+        },
+        "directory_service_group_uuid": {
+            "required": False,
+            "description": "UUID of the directory service group. Supply together with "
+            "directory_service_group_server_id to encode the value offline, without "
+            "an API lookup.",
+            "default": "",
+        },
+        "directory_service_group_server_id": {
+            "required": False,
+            "description": "ID of the Directory Service server the group belongs to, which "
+            "is either an LDAP server or a Cloud Identity Provider. Supply together with "
+            "directory_service_group_uuid to encode the value offline, without an API lookup.",
+            "default": "",
+        },
+        "output_variable_name": {
+            "required": False,
+            "description": "Optional name of an additional output variable to set to the "
+            "encoded value, e.g. 'DS_GROUP_VALUE' so that %DS_GROUP_VALUE% can be used in "
+            "a template.",
+            "default": "",
+        },
+        "skip_if": {
+            "required": False,
+            "description": "Skip the process if the supplied predicate evaluates to True.",
+            "default": False,
+        },
+    }
+
+    output_variables = {
+        "directory_service_group_value": {
+            "description": "The base64-encoded {uuid,serverId} criterion value."
+        },
+        "directory_service_group_name": {
+            "description": "The resolved directory service group name."
+        },
+        "directory_service_group_uuid": {
+            "description": "The UUID of the resolved directory service group."
+        },
+        "directory_service_group_server_id": {
+            "description": "The ID of the Directory Service server (LDAP server or Cloud "
+            "Identity Provider) the resolved group belongs to."
+        },
+        "process_skipped": {"description": "Returns True if the process was skipped."},
+    }
+
+    def main(self):
+        """Run the execute function"""
+
+        self.execute()
+
+
+if __name__ == "__main__":
+    PROCESSOR = JamfDirectoryServiceGroupEncoder()
+    PROCESSOR.execute_shell()

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfDirectoryServiceGroupEncoderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfDirectoryServiceGroupEncoderBase.py
@@ -85,7 +85,7 @@ class JamfDirectoryServiceGroupEncoderBase(JamfUploaderBase):
             )
         return ref
 
-    def get_directory_service_groups(self, api_url, token, group_name):
+    def get_directory_service_groups(self, api_url, token, group_name, tenant_id=""):
         """Return the directory service groups whose name matches group_name exactly.
 
         The API performs a 'contains' search across all configured Directory Service
@@ -93,7 +93,9 @@ class JamfDirectoryServiceGroupEncoderBase(JamfUploaderBase):
         searched include both LDAP servers and Cloud Identity Providers; the API returns
         the server's ID as 'ldapServerId' in both cases.
         """
-        url = f"{api_url}/api/v1/ldap/groups?q={quote(group_name)}"
+        object_type = "ldap_group"
+        endpoint = self.api_endpoints(object_type, tenant_id=tenant_id)
+        url = f"{api_url}/{endpoint}?q={quote(group_name)}"
         r = self.curl(api_type="jpapi", request="GET", url=url, token=token)
         if r.status_code != 200:
             raise ProcessorError(
@@ -102,12 +104,14 @@ class JamfDirectoryServiceGroupEncoderBase(JamfUploaderBase):
         results = r.output.get("results", []) if isinstance(r.output, dict) else []
         return [group for group in results if group.get("name") == group_name]
 
-    def resolve_ds_group_value(self, api_url, token, group_name):
+    def resolve_ds_group_value(self, api_url, token, group_name, tenant_id=""):
         """Resolve a directory service group name to its encoded criterion value.
 
         Returns a tuple of (encoded value, uuid, Directory Service server id).
         """
-        groups = self.get_directory_service_groups(api_url, token, group_name)
+        groups = self.get_directory_service_groups(
+            api_url, token, group_name, tenant_id=tenant_id
+        )
         if not groups:
             raise ProcessorError(
                 f"ERROR: no directory service group named '{group_name}' was found on "
@@ -230,7 +234,10 @@ class JamfDirectoryServiceGroupEncoderBase(JamfUploaderBase):
 
                 self.output(f"Looking up directory service group '{group_name}'")
                 encoded_value, group_uuid, server_id = self.resolve_ds_group_value(
-                    api_url, token, group_name
+                    api_url,
+                    token,
+                    group_name,
+                    tenant_id=jamf_platform_gw_tenant_id,
                 )
 
         self.output(f"Directory service group criterion value: {encoded_value}")

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfDirectoryServiceGroupEncoderBase.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfDirectoryServiceGroupEncoderBase.py
@@ -1,0 +1,248 @@
+#!/usr/local/autopkg/python
+# pylint: disable=invalid-name
+
+"""
+2026 Neil Martin
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import base64
+import binascii
+import json
+import os
+import sys
+
+from urllib.parse import quote
+
+from autopkglib import (  # pylint: disable=import-error
+    ProcessorError,
+)
+
+# to use a base module in AutoPkg we need to add this path to the sys.path.
+# this violates flake8 E402 (PEP8 imports) but is unavoidable, so the following
+# imports require noqa comments for E402
+sys.path.insert(0, os.path.dirname(__file__))
+
+from JamfUploaderBase import (  # pylint: disable=import-error, wrong-import-position
+    JamfUploaderBase,
+)
+
+
+class JamfDirectoryServiceGroupEncoderBase(JamfUploaderBase):
+    """Class for functions used to encode a directory service group criterion value"""
+
+    def encode_ds_group_value(self, uuid, server_id):
+        """Return the base64-encoded criterion value for a directory service group.
+
+        The key order and the string type of serverId both matter: they must match
+        what the Jamf Pro interface writes, so that a value written by JamfUploader
+        is byte-identical to one written by hand.
+        """
+        ref = {"uuid": str(uuid), "serverId": str(server_id)}
+        return base64.b64encode(
+            json.dumps(ref, separators=(",", ":")).encode("utf-8")
+        ).decode("utf-8")
+
+    def decode_ds_group_value(self, value):
+        """Return the decoded {uuid,serverId} dict if value is an encoded directory
+        service group value, otherwise None (i.e. value is a group name).
+
+        Raises a ProcessorError if the value looks encoded but is malformed, so that
+        a typo in a pasted value is not uploaded as if it were a group name.
+        """
+        try:
+            decoded = base64.b64decode(value, validate=True)
+        except (binascii.Error, ValueError):
+            return None
+        try:
+            ref = json.loads(decoded)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        if not isinstance(ref, dict) or not ("uuid" in ref or "serverId" in ref):
+            return None
+
+        # it looked encoded, so any defect is an error rather than a group name
+        if not ref.get("uuid"):
+            raise ProcessorError(
+                "ERROR: encoded directory service group value has an empty uuid. The "
+                "directory lookup returned no uuid mapping for this group (e.g. Okta "
+                "with default mappings). Jamf Pro will not save a criterion without a uuid."
+            )
+        if not ref.get("serverId"):
+            raise ProcessorError(
+                "ERROR: encoded directory service group value has an empty serverId"
+            )
+        return ref
+
+    def get_directory_service_groups(self, api_url, token, group_name):
+        """Return the directory service groups whose name matches group_name exactly.
+
+        The API performs a 'contains' search across all configured Directory Service
+        servers, so the results are filtered to an exact name match here. The servers
+        searched include both LDAP servers and Cloud Identity Providers; the API returns
+        the server's ID as 'ldapServerId' in both cases.
+        """
+        url = f"{api_url}/api/v1/ldap/groups?q={quote(group_name)}"
+        r = self.curl(api_type="jpapi", request="GET", url=url, token=token)
+        if r.status_code != 200:
+            raise ProcessorError(
+                f"ERROR: directory service group search failed (HTTP {r.status_code})"
+            )
+        results = r.output.get("results", []) if isinstance(r.output, dict) else []
+        return [group for group in results if group.get("name") == group_name]
+
+    def resolve_ds_group_value(self, api_url, token, group_name):
+        """Resolve a directory service group name to its encoded criterion value.
+
+        Returns a tuple of (encoded value, uuid, Directory Service server id).
+        """
+        groups = self.get_directory_service_groups(api_url, token, group_name)
+        if not groups:
+            raise ProcessorError(
+                f"ERROR: no directory service group named '{group_name}' was found on "
+                "any configured Directory Service server. The name must match exactly, "
+                "including case."
+            )
+        if len(groups) > 1:
+            servers = ", ".join(str(group.get("ldapServerId")) for group in groups)
+            raise ProcessorError(
+                f"ERROR: '{group_name}' matches groups on more than one Directory "
+                f"Service server (server IDs: {servers}). Supply "
+                "directory_service_group_uuid and directory_service_group_server_id "
+                "to specify which group to use."
+            )
+
+        group = groups[0]
+        uuid = group.get("uuid")
+        server_id = group.get("ldapServerId")
+        if not uuid:
+            raise ProcessorError(
+                f"ERROR: directory service group '{group_name}' has no uuid mapping. "
+                "Jamf Pro will not save a criterion without a uuid - check the Directory "
+                "Service mappings for the group's object class."
+            )
+        self.output(
+            f"Resolved '{group_name}': uuid {uuid}, Directory Service server "
+            f"ID {server_id}",
+            verbose_level=2,
+        )
+        return (
+            self.encode_ds_group_value(uuid, server_id),
+            uuid,
+            str(server_id),
+        )
+
+    def execute(self):
+        """Encode a directory service group criterion value"""
+        jamf_url = (self.env.get("JSS_URL") or "").rstrip("/")
+        jamf_user = self.env.get("API_USERNAME")
+        jamf_password = self.env.get("API_PASSWORD")
+        jamf_platform_gw_region = self.env.get("PLATFORM_API_REGION")
+        jamf_platform_gw_tenant_id = self.env.get("PLATFORM_API_TENANT_ID")
+        client_id = self.env.get("CLIENT_ID")
+        client_secret = self.env.get("CLIENT_SECRET")
+        bearer_token = self.env.get("BEARER_TOKEN")
+        jamf_cli_profile = self.env.get("JAMF_CLI_PROFILE")
+        group_name = self.env.get("directory_service_group_name") or ""
+        group_uuid = self.env.get("directory_service_group_uuid") or ""
+        server_id = self.env.get("directory_service_group_server_id") or ""
+        output_variable_name = self.env.get("output_variable_name") or ""
+        skip_if = self.get_and_clear_skip_if()
+
+        process_skipped = False
+
+        # skip the process if skip_if is True
+        if skip_if and self.predicate_evaluates_as_true(skip_if):
+            self.output("Skipping to next process as skip_if evaluated to True")
+            process_skipped = True
+            self.env["process_skipped"] = process_skipped
+            return
+        elif skip_if:
+            self.output("Not skipping process as skip_if evaluated to False")
+
+        # substitute user-assignable keys
+        group_name = self.substitute_assignable_keys(group_name)
+
+        if group_uuid and server_id:
+            # encode offline, no API lookup required
+            self.output(
+                f"Encoding supplied uuid {group_uuid} and Directory Service server "
+                f"ID {server_id}"
+            )
+            encoded_value = self.encode_ds_group_value(group_uuid, server_id)
+        elif group_uuid or server_id:
+            raise ProcessorError(
+                "ERROR: directory_service_group_uuid and "
+                "directory_service_group_server_id must be supplied together"
+            )
+        elif not group_name:
+            raise ProcessorError(
+                "ERROR: supply either directory_service_group_name, or both "
+                "directory_service_group_uuid and directory_service_group_server_id"
+            )
+        else:
+            # an already-encoded value is validated and passed through unchanged
+            decoded = self.decode_ds_group_value(group_name)
+            if decoded:
+                self.output(
+                    "Supplied value is already an encoded directory service group "
+                    "value, passing it through unchanged"
+                )
+                encoded_value = group_name
+                group_uuid = decoded["uuid"]
+                server_id = decoded["serverId"]
+                group_name = ""
+            else:
+                # get a token
+                (
+                    token,
+                    jamf_url,
+                    jamf_platform_gw_region,
+                    jamf_platform_gw_tenant_id,
+                ) = self.auth(
+                    jamf_url=jamf_url,
+                    jamf_user=jamf_user,
+                    password=jamf_password,
+                    region=jamf_platform_gw_region,
+                    tenant_id=jamf_platform_gw_tenant_id,
+                    client_id=client_id,
+                    client_secret=client_secret,
+                    token=bearer_token,
+                    jamf_cli_profile=jamf_cli_profile,
+                )
+
+                # construct the api_url based on the API type
+                api_url = self.construct_api_url(
+                    jamf_url=jamf_url, region=jamf_platform_gw_region
+                )
+                self.output(f"API URL is {api_url}", verbose_level=3)
+
+                self.output(f"Looking up directory service group '{group_name}'")
+                encoded_value, group_uuid, server_id = self.resolve_ds_group_value(
+                    api_url, token, group_name
+                )
+
+        self.output(f"Directory service group criterion value: {encoded_value}")
+
+        # output the results
+        self.env["directory_service_group_value"] = encoded_value
+        self.env["directory_service_group_name"] = group_name
+        self.env["directory_service_group_uuid"] = group_uuid
+        self.env["directory_service_group_server_id"] = str(server_id)
+        if output_variable_name:
+            self.env[output_variable_name] = encoded_value
+            self.output(
+                f"Set '{output_variable_name}' to the encoded value", verbose_level=2
+            )
+        self.env["process_skipped"] = process_skipped

--- a/JamfUploaderProcessors/JamfUploaderLib/JamfSchemaRegistry.py
+++ b/JamfUploaderProcessors/JamfUploaderLib/JamfSchemaRegistry.py
@@ -131,6 +131,7 @@ JPAPI_ALIAS_TABLE = {
     "jamf_protect_settings": "v1/jamf-protect",
     "jcds": "v1/jcds",
     "laps_settings": "v2/local-admin-password/settings",
+    "ldap_group": "v1/ldap/groups",
     "managed_software_updates_available_updates": (
         "v1/managed-software-updates/available-updates"
     ),

--- a/JamfUploaderProcessors/READMEs/JamfDirectoryServiceGroupEncoder.md
+++ b/JamfUploaderProcessors/READMEs/JamfDirectoryServiceGroupEncoder.md
@@ -1,0 +1,79 @@
+# JamfDirectoryServiceGroupEncoder
+
+## Description
+
+A processor for AutoPkg that resolves a Directory Service group name to the base64-encoded value required by *directory service group* criteria in smart groups and advanced searches (Jamf Pro 11.29 and later).
+
+These criteria do not take a group name as their value. They take a base64-encoded JSON object of the form `{"uuid":"E5EFCA3E-892C-4CCE-B2C1-6CA1A32E9153","serverId":"31"}`. This processor looks the group up via the `/api/v1/ldap/groups` endpoint, which searches every configured Directory Service, whether it is an LDAP server or a Cloud Identity Provider such as Okta or Entra ID. It then encodes the value and returns it as the `directory_service_group_value` output variable, for substitution into a template that is uploaded with `JamfComputerGroupUploader`, `JamfMobileDeviceGroupUploader` or `JamfObjectUploader`.
+
+The criteria that take one of these values are documented by Jamf in [Directory Service Group Criteria](https://learn.jamf.com/r/en-US/jamf-pro-documentation-current/Directory_Service_Group_Criteria). Which of them are accepted depends on the object being uploaded:
+
+- `Assigned User directory service group` - computer and mobile objects.
+- `Username directory service group` - computer, mobile and user objects.
+- `User last logged in - Computer directory service group` - computer objects only.
+- `User last logged in - Self Service directory service group` - computer and mobile objects.
+- `User last logged in - Mdm directory service group` - computer and mobile objects.
+
+Here, computer objects are computer groups and advanced computer searches, mobile objects are mobile device groups and advanced mobile device searches, and user objects are user groups and advanced user searches.
+
+The criterion names are case-sensitive, and the API rejects an unrecognised name with an empty HTTP 409 response, giving no indication of what was wrong. Note that two of the names above are cased differently to the Jamf documentation, which lists them as `User last logged in - MDM directory service group` and `Assigned user directory service group`. Both of those forms are rejected; the forms listed above are the ones the API accepts.
+
+Membership is not immediate. Jamf Pro caches directory user information locally and syncs every 20 minutes, so a group uploaded by this processor may take some time to populate.
+
+## Input variables
+
+- **JSS_URL:**
+  - **required:** True
+  - **description:** URL to a Jamf Pro server that the API user has write access to, optionally set as a key in the com.github.autopkg preference file.
+- **API_USERNAME:**
+  - **required:** False
+  - **description:** Username of account with appropriate access to jss, optionally set as a key in the com.github.autopkg preference file.
+- **API_PASSWORD:**
+  - **required:** False
+  - **description:** Password of api user, optionally set as a key in the com.github.autopkg preference file.
+- **CLIENT_ID:**
+  - **required:** False
+  - **description:** Client ID with access to jss, optionally set as a key in the com.github.autopkg preference file.
+- **CLIENT_SECRET:**
+  - **required:** False
+  - **description:** Secret associated with the Client ID, optionally set as a key in the com.github.autopkg preference file.
+- **BEARER_TOKEN:**
+  - **required:** False
+  - **description:** A pre-existing bearer token for the Jamf Pro API. If provided, the token will be validated and used directly, bypassing credential-based authentication.
+- **JAMF_CLI_PROFILE:**
+  - **required:** False
+  - **description:** A jamf-cli profile to use to obtain a bearer token. Requires jamf-cli to be installed and in the PATH. Set to a profile name to enable.
+- **PLATFORM_API_REGION:**
+  - **required:** False
+  - **description:** Region for Jamf Platform API Gateway (e.g. `us1`, `eu1`, `au1`). Required for Platform API authentication.
+- **PLATFORM_API_TENANT_ID:**
+  - **required:** False
+  - **description:** Tenant ID for Jamf Platform API Gateway. Required for Platform API authentication.
+- **directory_service_group_name:**
+  - **required:** False
+  - **description:** Name of the directory service group to resolve. Must match the group name in the directory exactly, including case. An already-encoded base64 value may also be supplied here, in which case it is validated and passed through unchanged. If the name exists on more than one Directory Service server the lookup is ambiguous and the processor fails, in which case supply `directory_service_group_uuid` and `directory_service_group_server_id` instead. Not required if those two are both supplied.
+- **directory_service_group_uuid:**
+  - **required:** False
+  - **description:** UUID of the directory service group. Supply together with `directory_service_group_server_id` to encode the value offline, without an API lookup.
+- **directory_service_group_server_id:**
+  - **required:** False
+  - **description:** ID of the Directory Service server the group belongs to, which is either an LDAP server or a Cloud Identity Provider. Supply together with `directory_service_group_uuid` to encode the value offline, without an API lookup.
+- **output_variable_name:**
+  - **required:** False
+  - **description:** Name of an additional output variable to set to the encoded value, e.g. `DS_GROUP_VALUE` so that `%DS_GROUP_VALUE%` can be used in a template. Useful when encoding more than one group in a single recipe.
+- **skip_if:**
+  - **required:** False
+  - **description:** Skip the process if a supplied predicate is met.
+
+## Output variables
+
+- **directory_service_group_value:**
+  - **description:** The base64-encoded criterion value. Substitute this into the `value` key of the criterion in the template.
+- **directory_service_group_name:**
+  - **description:** The resolved directory service group name. Empty if an already-encoded value was supplied.
+- **directory_service_group_uuid:**
+  - **description:** The UUID of the resolved directory service group. A group whose Directory Service mappings return no UUID cannot be used, as Jamf Pro will not save a criterion without one, so the processor fails rather than uploading a value that the server rejects.
+- **directory_service_group_server_id:**
+  - **description:** The ID of the Directory Service server (LDAP server or Cloud Identity Provider) the resolved group belongs to.
+- **process_skipped:**
+  - **description:** Boolean - True if the process was skipped due to skip_if predicate resolved to True.

--- a/_tests/test_schema_registry.py
+++ b/_tests/test_schema_registry.py
@@ -476,7 +476,7 @@ assert result["endpoint"] == "JSSResource/policies"
 print(f"  resolve('policy') Classic precedence: PASS -> {result['endpoint']}")
 
 # Test 22: Verify JPAPI_ALIAS_TABLE has all expected entries
-expected_alias_count = 56
+expected_alias_count = 58
 actual_alias_count = len(JPAPI_ALIAS_TABLE)
 assert actual_alias_count == expected_alias_count, (
     f"JPAPI_ALIAS_TABLE should have {expected_alias_count} entries, "


### PR DESCRIPTION
Apologies for any AI sloppiness, Claude helped on this one.

Adds `JamfDirectoryServiceGroupEncoder`.

The directory service group criteria added in Jamf Pro 11.29 don't take a group name as their value. They take a base64 encoded JSON object of the form `{"uuid":"E5EFCA3E-892C-4CCE-B2C1-6CA1A32E9153","serverId":"31"}`, which is a pain to build by hand and impossible to keep in a template. This processor looks the group up on `/api/v1/ldap/groups`, encodes the value and hands it back as `directory_service_group_value` for substitution.

It's a standalone processor rather than something baked into the group uploaders, because six object types can carry these criteria: computer groups, mobile device groups, user groups and all three advanced searches. Four of those go through `JamfObjectUploader`, so putting the logic in the group uploaders would only cover a third of the cases and duplicate it.

Template:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<computer_group>
    <name>Directory Service Group Members</name>
    <is_smart>true</is_smart>
    <criteria>
        <criterion>
            <name>Username directory service group</name>
            <priority>0</priority>
            <and_or>and</and_or>
            <search_type>member of</search_type>
            <value>%directory_service_group_value%</value>
        </criterion>
    </criteria>
</computer_group>
```

Recipe stub:

```yaml
Process:
  - Processor: com.github.grahampugh.jamf-upload.processors/JamfDirectoryServiceGroupEncoder
    Arguments:
      directory_service_group_name: "JamfPro_Admins"

  - Processor: com.github.grahampugh.jamf-upload.processors/JamfComputerGroupUploader
    Arguments:
      computergroup_name: "Directory Service Group Members"
      computergroup_template: SmartGroup-DirectoryServiceGroup.xml
      replace_group: True
```

`output_variable_name` sets an extra output variable if you need to encode more than one group in a recipe. You can also pass `directory_service_group_uuid` and `directory_service_group_server_id` to encode without an API lookup.

A few things worth knowing, all of them found by testing:

The criterion names are case sensitive and the API rejects an unknown one with an empty 409, so there's nothing to go on when you get it wrong. Two of the names in [Jamf's documentation](https://learn.jamf.com/r/en-US/jamf-pro-documentation-current/Directory_Service_Group_Criteria) are cased wrong. `User last logged in - MDM directory service group` and `Assigned user directory service group` are both rejected. `Mdm` and `Assigned User` are accepted. The other three names match the docs.

The variables are named `..._server_id` rather than `..._ldap_server_id`, because the encoded value's own key is `serverId` and the same ID covers LDAP servers and cloud IdPs. The API returns it as `ldapServerId` either way.

A group whose Group UUID mapping returns nothing can't be used at all, as Jamf Pro won't save the criterion without a uuid. That's the Okta default mappings case in Jamf's docs. The processor fails with an explanation rather than uploading something the server will reject.

There's no `dry_run` input, as the processor only does a GET.

Tested against a Jamf Pro instance with an LDAP server configured:

- Group name resolved to uuid and server ID, encoded, uploaded in a smart group template and read back with the value stored identically. The group populated with a real member.
- Same again for a second group and a different criterion.
- Passing an already encoded value through unchanged, and encoding offline from uuid and server ID. Both produce the same value as the lookup.
- Group not found, ambiguous name and mismatched uuid or server ID arguments all raise a sensible error.
- All four criterion name casings above, plus a computer only criterion on a mobile device group, which is where the empty 409s turned up.

Test objects were all deleted afterwards.

Output from a test run, with the server name, profile name, group name and uuid changed:

```
JamfDirectoryServiceGroupEncoder: Handling authentication for Pro/Classic API
JamfDirectoryServiceGroupEncoder: Using jamf-cli to get token for https://myserver.jamfcloud.com (pro API)
JamfDirectoryServiceGroupEncoder: Requesting token from jamf-cli for profile myserver
JamfDirectoryServiceGroupEncoder: Pro/Classic API token received via jamf-cli
JamfDirectoryServiceGroupEncoder: Looking up directory service group 'Jamf_Pro_Admins'
JamfDirectoryServiceGroupEncoder: Directory service group criterion value: eyJ1dWlkIjoiMUY0QTlDMkUtN0IzRC00RTU2LTlBODEtMEM1RDZFN0Y4QTlCIiwic2VydmVySWQiOiIxIn0=
JamfComputerGroupUploader: Handling authentication for Pro/Classic API
JamfComputerGroupUploader: Using jamf-cli to get token for https://myserver.jamfcloud.com (pro API)
JamfComputerGroupUploader: Requesting token from jamf-cli for profile myserver
JamfComputerGroupUploader: Pro/Classic API token received via jamf-cli
JamfComputerGroupUploader: Checking for existing 'JamfUploaderTest-DSGroup' on https://myserver.jamfcloud.com
JamfComputerGroupUploader: Uploading Computer Group...
JamfComputerGroupUploader: Computer Group 'JamfUploaderTest-DSGroup' upload successful
```

Reading the group back shows the value stored as it was sent:

```xml
  <criteria>
    <size>1</size>
    <criterion>
      <name>Username directory service group</name>
      <priority>0</priority>
      <and_or>and</and_or>
      <search_type>member of</search_type>
      <value>eyJ1dWlkIjoiMUY0QTlDMkUtN0IzRC00RTU2LTlBODEtMEM1RDZFN0Y4QTlCIiwic2VydmVySWQiOiIxIn0=</value>
      <opening_paren>false</opening_paren>
      <closing_paren>false</closing_paren>
    </criterion>
  </criteria>
```
